### PR TITLE
feat: AppVersion 업로드/테스트/심사 및 Review 도메인 구현

### DIFF
--- a/src/main/java/com/union/union/domain/appversion/controller/AppVersionController.java
+++ b/src/main/java/com/union/union/domain/appversion/controller/AppVersionController.java
@@ -1,0 +1,80 @@
+package com.union.union.domain.appversion.controller;
+
+import com.union.union.domain.appversion.dto.AppVersionResponseDto;
+import com.union.union.domain.appversion.dto.CreateVersionRequestDto;
+import com.union.union.domain.appversion.dto.CreateVersionResponseDto;
+import com.union.union.domain.appversion.service.AppVersionService;
+import com.union.union.global.security.jwt.JwtUserPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/app-versions")
+@RequiredArgsConstructor
+public class AppVersionController {
+
+    private final AppVersionService appVersionService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('PUBLISHER')")
+    public ResponseEntity<CreateVersionResponseDto> createVersion(
+            @Valid @RequestBody CreateVersionRequestDto request,
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        CreateVersionResponseDto response = appVersionService.createVersion(request, principal.userId());
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @PostMapping("/{id}/confirm")
+    @PreAuthorize("hasRole('PUBLISHER')")
+    public ResponseEntity<AppVersionResponseDto> confirmUpload(
+            @PathVariable UUID id,
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        AppVersionResponseDto response = appVersionService.confirmUpload(id, principal.userId());
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{id}/test-complete")
+    @PreAuthorize("hasRole('PUBLISHER')")
+    public ResponseEntity<AppVersionResponseDto> markTested(
+            @PathVariable UUID id,
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        AppVersionResponseDto response = appVersionService.markTested(id, principal.userId());
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{id}/bundle")
+    public ResponseEntity<Map<String, String>> getBundleUrl(
+            @PathVariable UUID id
+    ) {
+        String downloadUrl = appVersionService.getBundleDownloadUrl(id);
+        return ResponseEntity.ok(Map.of("downloadUrl", downloadUrl));
+    }
+
+    @GetMapping("/mini-app/{miniAppId}")
+    @PreAuthorize("hasRole('PUBLISHER')")
+    public ResponseEntity<List<AppVersionResponseDto>> getVersionsByMiniApp(
+            @PathVariable Long miniAppId
+    ) {
+        List<AppVersionResponseDto> response = appVersionService.getVersionsByMiniApp(miniAppId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasRole('PUBLISHER') or hasRole('ADMIN')")
+    public ResponseEntity<AppVersionResponseDto> getVersion(@PathVariable UUID id) {
+        AppVersionResponseDto response = appVersionService.getVersion(id);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/union/union/domain/appversion/dto/AppVersionResponseDto.java
+++ b/src/main/java/com/union/union/domain/appversion/dto/AppVersionResponseDto.java
@@ -1,0 +1,39 @@
+package com.union.union.domain.appversion.dto;
+
+import com.union.union.domain.appversion.entity.AppVersion;
+import com.union.union.domain.appversion.entity.VersionStatus;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record AppVersionResponseDto(
+    UUID id,
+    Long miniAppId,
+    String miniAppName,
+    String publisherNickname,
+    String versionNumber,
+    String releaseNotes,
+    VersionStatus status,
+    String buildFileUrl,
+    Long bundleSize,
+    LocalDateTime testedAt,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+) {
+    public static AppVersionResponseDto from(AppVersion version) {
+        return new AppVersionResponseDto(
+            version.getId(),
+            version.getMiniApp().getId(),
+            version.getMiniApp().getName(),
+            version.getPublisher().getNickname(),
+            version.getVersionNumber(),
+            version.getReleaseNotes(),
+            version.getStatus(),
+            version.getBuildFileUrl(),
+            version.getBundleSize(),
+            version.getTestedAt(),
+            version.getCreatedAt(),
+            version.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/union/union/domain/appversion/dto/CreateVersionRequestDto.java
+++ b/src/main/java/com/union/union/domain/appversion/dto/CreateVersionRequestDto.java
@@ -1,0 +1,17 @@
+package com.union.union.domain.appversion.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record CreateVersionRequestDto(
+    @NotNull(message = "miniAppId는 필수입니다")
+    Long miniAppId,
+
+    @NotBlank(message = "버전 번호는 필수입니다")
+    @Pattern(regexp = "^\\d+\\.\\d+\\.\\d+$", message = "버전 번호는 semver 형식이어야 합니다 (예: 1.0.0)")
+    String versionNumber,
+
+    String releaseNotes
+) {
+}

--- a/src/main/java/com/union/union/domain/appversion/dto/CreateVersionResponseDto.java
+++ b/src/main/java/com/union/union/domain/appversion/dto/CreateVersionResponseDto.java
@@ -1,0 +1,9 @@
+package com.union.union.domain.appversion.dto;
+
+import java.util.UUID;
+
+public record CreateVersionResponseDto(
+    UUID versionId,
+    String uploadUrl
+) {
+}

--- a/src/main/java/com/union/union/domain/appversion/entity/AppVersion.java
+++ b/src/main/java/com/union/union/domain/appversion/entity/AppVersion.java
@@ -1,0 +1,102 @@
+package com.union.union.domain.appversion.entity;
+
+import com.union.union.domain.miniapp.entity.MiniApp;
+import com.union.union.domain.user.entity.User;
+import com.union.union.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "app_versions")
+public class AppVersion extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "uuid")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mini_app_id", nullable = false)
+    private MiniApp miniApp;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "publisher_id", nullable = false)
+    private User publisher;
+
+    @Column(nullable = false, length = 20)
+    private String versionNumber;
+
+    @Column(columnDefinition = "TEXT")
+    private String releaseNotes;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private VersionStatus status;
+
+    @Column(length = 500)
+    private String buildFileUrl;
+
+    private Long bundleSize;
+
+    private LocalDateTime testedAt;
+
+    @Builder
+    public AppVersion(MiniApp miniApp, User publisher, String versionNumber, String releaseNotes) {
+        this.miniApp = miniApp;
+        this.publisher = publisher;
+        this.versionNumber = versionNumber;
+        this.releaseNotes = releaseNotes;
+        this.status = VersionStatus.DRAFT;
+    }
+
+    public void confirmUpload(String buildFileUrl, Long bundleSize) {
+        if (this.status != VersionStatus.DRAFT) {
+            throw new IllegalStateException("DRAFT 상태에서만 업로드를 확정할 수 있습니다");
+        }
+        this.buildFileUrl = buildFileUrl;
+        this.bundleSize = bundleSize;
+        this.status = VersionStatus.UPLOADED;
+    }
+
+    public void markTested() {
+        if (this.testedAt == null) {
+            this.testedAt = LocalDateTime.now();
+        }
+    }
+
+    public void submitForReview() {
+        if (this.status != VersionStatus.UPLOADED) {
+            throw new IllegalStateException("UPLOADED 상태에서만 심사를 요청할 수 있습니다");
+        }
+        if (this.testedAt == null) {
+            throw new IllegalStateException("최소 1회 테스트 후 심사를 요청할 수 있습니다");
+        }
+        this.status = VersionStatus.IN_REVIEW;
+    }
+
+    public void accept() {
+        if (this.status != VersionStatus.IN_REVIEW) {
+            throw new IllegalStateException("IN_REVIEW 상태에서만 승인할 수 있습니다");
+        }
+        this.status = VersionStatus.ACCEPTED;
+    }
+
+    public void reject() {
+        if (this.status != VersionStatus.IN_REVIEW) {
+            throw new IllegalStateException("IN_REVIEW 상태에서만 거절할 수 있습니다");
+        }
+        this.status = VersionStatus.REJECTED;
+    }
+
+    public void deploy() {
+        if (this.status != VersionStatus.ACCEPTED) {
+            throw new IllegalStateException("ACCEPTED 상태에서만 배포할 수 있습니다");
+        }
+        this.status = VersionStatus.DEPLOYED;
+    }
+}

--- a/src/main/java/com/union/union/domain/appversion/entity/VersionStatus.java
+++ b/src/main/java/com/union/union/domain/appversion/entity/VersionStatus.java
@@ -1,0 +1,10 @@
+package com.union.union.domain.appversion.entity;
+
+public enum VersionStatus {
+    DRAFT,
+    UPLOADED,
+    IN_REVIEW,
+    ACCEPTED,
+    REJECTED,
+    DEPLOYED
+}

--- a/src/main/java/com/union/union/domain/appversion/repository/AppVersionRepository.java
+++ b/src/main/java/com/union/union/domain/appversion/repository/AppVersionRepository.java
@@ -1,0 +1,19 @@
+package com.union.union.domain.appversion.repository;
+
+import com.union.union.domain.appversion.entity.AppVersion;
+import com.union.union.domain.appversion.entity.VersionStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface AppVersionRepository extends JpaRepository<AppVersion, UUID> {
+
+    List<AppVersion> findByMiniAppIdOrderByCreatedAtDesc(Long miniAppId);
+
+    List<AppVersion> findByPublisherIdOrderByCreatedAtDesc(UUID publisherId);
+
+    List<AppVersion> findByStatus(VersionStatus status);
+}

--- a/src/main/java/com/union/union/domain/appversion/service/AppVersionService.java
+++ b/src/main/java/com/union/union/domain/appversion/service/AppVersionService.java
@@ -1,0 +1,133 @@
+package com.union.union.domain.appversion.service;
+
+import com.google.cloud.storage.Blob;
+import com.google.cloud.storage.Storage;
+import com.union.union.domain.appversion.dto.AppVersionResponseDto;
+import com.union.union.domain.appversion.dto.CreateVersionRequestDto;
+import com.union.union.domain.appversion.dto.CreateVersionResponseDto;
+import com.union.union.domain.appversion.entity.AppVersion;
+import com.union.union.domain.appversion.repository.AppVersionRepository;
+import com.union.union.domain.miniapp.entity.MiniApp;
+import com.union.union.domain.miniapp.repository.MiniAppRepository;
+import com.union.union.domain.user.entity.User;
+import com.union.union.domain.user.repository.UserRepository;
+import com.union.union.global.infra.gcs.GcsService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AppVersionService {
+
+    private final AppVersionRepository appVersionRepository;
+    private final MiniAppRepository miniAppRepository;
+    private final UserRepository userRepository;
+    private final GcsService gcsService;
+    private final Storage storage;
+
+    @Value("${spring.cloud.gcp.storage.bucket}")
+    private String bucketName;
+
+    @Transactional
+    public CreateVersionResponseDto createVersion(CreateVersionRequestDto request, UUID publisherId) {
+        User publisher = userRepository.findById(publisherId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+
+        MiniApp miniApp = miniAppRepository.findById(request.miniAppId())
+                .orElseThrow(() -> new IllegalArgumentException("MiniApp을 찾을 수 없습니다"));
+
+        if (!miniApp.getPublisher().getId().equals(publisherId)) {
+            throw new IllegalArgumentException("본인의 MiniApp에만 버전을 추가할 수 있습니다");
+        }
+
+        AppVersion version = AppVersion.builder()
+                .miniApp(miniApp)
+                .publisher(publisher)
+                .versionNumber(request.versionNumber())
+                .releaseNotes(request.releaseNotes())
+                .build();
+
+        appVersionRepository.save(version);
+
+        String filename = String.format("mini-apps/%s/versions/%s/bundle.zip",
+                miniApp.getId(), version.getId());
+        var signedUrlResponse = gcsService.getMiniAppSignedUrl(publisherId, filename);
+
+        log.info("AppVersion 생성 (DRAFT). versionId={}, miniAppId={}", version.getId(), miniApp.getId());
+
+        return new CreateVersionResponseDto(version.getId(), signedUrlResponse.signedUrl());
+    }
+
+    @Transactional
+    public AppVersionResponseDto confirmUpload(UUID versionId, UUID publisherId) {
+        AppVersion version = getVersionWithOwnerCheck(versionId, publisherId);
+
+        String objectPath = String.format("mini-apps/%s/versions/%s/bundle.zip",
+                version.getMiniApp().getId(), version.getId());
+
+        Blob blob = storage.get(bucketName, objectPath);
+        if (blob == null || !blob.exists()) {
+            throw new IllegalStateException("GCS에 파일이 존재하지 않습니다. 업로드를 먼저 완료해주세요");
+        }
+
+        version.confirmUpload(objectPath, blob.getSize());
+
+        log.info("AppVersion 업로드 확정 (UPLOADED). versionId={}, size={}bytes", versionId, blob.getSize());
+
+        return AppVersionResponseDto.from(version);
+    }
+
+    @Transactional
+    public AppVersionResponseDto markTested(UUID versionId, UUID publisherId) {
+        AppVersion version = getVersionWithOwnerCheck(versionId, publisherId);
+        version.markTested();
+
+        log.info("AppVersion 테스트 완료 기록. versionId={}", versionId);
+
+        return AppVersionResponseDto.from(version);
+    }
+
+    public String getBundleDownloadUrl(UUID versionId) {
+        AppVersion version = appVersionRepository.findById(versionId)
+                .orElseThrow(() -> new IllegalArgumentException("AppVersion을 찾을 수 없습니다"));
+
+        if (version.getBuildFileUrl() == null) {
+            throw new IllegalStateException("아직 업로드되지 않은 버전입니다");
+        }
+
+        return gcsService.getCdnDownloadUrl(version.getBuildFileUrl());
+    }
+
+    public List<AppVersionResponseDto> getVersionsByMiniApp(Long miniAppId) {
+        return appVersionRepository.findByMiniAppIdOrderByCreatedAtDesc(miniAppId)
+                .stream()
+                .map(AppVersionResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    public AppVersionResponseDto getVersion(UUID versionId) {
+        AppVersion version = appVersionRepository.findById(versionId)
+                .orElseThrow(() -> new IllegalArgumentException("AppVersion을 찾을 수 없습니다"));
+        return AppVersionResponseDto.from(version);
+    }
+
+    private AppVersion getVersionWithOwnerCheck(UUID versionId, UUID publisherId) {
+        AppVersion version = appVersionRepository.findById(versionId)
+                .orElseThrow(() -> new IllegalArgumentException("AppVersion을 찾을 수 없습니다"));
+
+        if (!version.getPublisher().getId().equals(publisherId)) {
+            throw new IllegalArgumentException("본인의 버전만 수정할 수 있습니다");
+        }
+
+        return version;
+    }
+}

--- a/src/main/java/com/union/union/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/union/union/domain/review/controller/ReviewController.java
@@ -1,0 +1,60 @@
+package com.union.union.domain.review.controller;
+
+import com.union.union.domain.review.dto.ReviewDecisionRequestDto;
+import com.union.union.domain.review.dto.ReviewResponseDto;
+import com.union.union.domain.review.dto.SubmitReviewRequestDto;
+import com.union.union.domain.review.service.ReviewService;
+import com.union.union.global.security.jwt.JwtUserPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/reviews")
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('PUBLISHER')")
+    public ResponseEntity<ReviewResponseDto> submitForReview(
+            @Valid @RequestBody SubmitReviewRequestDto request,
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        ReviewResponseDto response = reviewService.submitForReview(request.versionId(), principal.userId());
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @GetMapping("/pending")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<List<ReviewResponseDto>> getPendingReviews() {
+        List<ReviewResponseDto> response = reviewService.getPendingReviews();
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ReviewResponseDto> getReview(@PathVariable UUID id) {
+        ReviewResponseDto response = reviewService.getReview(id);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/{id}/decision")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ResponseEntity<ReviewResponseDto> decide(
+            @PathVariable UUID id,
+            @Valid @RequestBody ReviewDecisionRequestDto request,
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        ReviewResponseDto response = reviewService.decide(id, request, principal.userId());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/union/union/domain/review/dto/ReviewDecisionRequestDto.java
+++ b/src/main/java/com/union/union/domain/review/dto/ReviewDecisionRequestDto.java
@@ -1,0 +1,12 @@
+package com.union.union.domain.review.dto;
+
+import com.union.union.domain.review.entity.Verdict;
+import jakarta.validation.constraints.NotNull;
+
+public record ReviewDecisionRequestDto(
+    @NotNull(message = "심사 결과는 필수입니다")
+    Verdict verdict,
+
+    String reason
+) {
+}

--- a/src/main/java/com/union/union/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/union/union/domain/review/dto/ReviewResponseDto.java
@@ -1,0 +1,35 @@
+package com.union.union.domain.review.dto;
+
+import com.union.union.domain.review.entity.Review;
+import com.union.union.domain.review.entity.Verdict;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record ReviewResponseDto(
+    UUID id,
+    UUID versionId,
+    String versionNumber,
+    String miniAppName,
+    String publisherNickname,
+    String reviewerNickname,
+    Verdict verdict,
+    String reason,
+    LocalDateTime submittedAt,
+    LocalDateTime decidedAt
+) {
+    public static ReviewResponseDto from(Review review) {
+        return new ReviewResponseDto(
+            review.getId(),
+            review.getVersion().getId(),
+            review.getVersion().getVersionNumber(),
+            review.getVersion().getMiniApp().getName(),
+            review.getVersion().getPublisher().getNickname(),
+            review.getReviewer() != null ? review.getReviewer().getNickname() : null,
+            review.getVerdict(),
+            review.getReason(),
+            review.getCreatedAt(),
+            review.getDecidedAt()
+        );
+    }
+}

--- a/src/main/java/com/union/union/domain/review/dto/SubmitReviewRequestDto.java
+++ b/src/main/java/com/union/union/domain/review/dto/SubmitReviewRequestDto.java
@@ -1,0 +1,11 @@
+package com.union.union.domain.review.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record SubmitReviewRequestDto(
+    @NotNull(message = "versionId는 필수입니다")
+    UUID versionId
+) {
+}

--- a/src/main/java/com/union/union/domain/review/entity/Review.java
+++ b/src/main/java/com/union/union/domain/review/entity/Review.java
@@ -1,0 +1,58 @@
+package com.union.union.domain.review.entity;
+
+import com.union.union.domain.appversion.entity.AppVersion;
+import com.union.union.domain.user.entity.User;
+import com.union.union.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "reviews")
+public class Review extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "uuid")
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "version_id", nullable = false)
+    private AppVersion version;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewer_id")
+    private User reviewer;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Verdict verdict;
+
+    @Column(columnDefinition = "TEXT")
+    private String reason;
+
+    private LocalDateTime decidedAt;
+
+    @Builder
+    public Review(AppVersion version) {
+        this.version = version;
+        this.verdict = Verdict.PENDING;
+    }
+
+    public void decide(User reviewer, Verdict verdict, String reason) {
+        if (this.verdict != Verdict.PENDING) {
+            throw new IllegalStateException("이미 처리된 심사입니다");
+        }
+        if (verdict == Verdict.REJECTED && (reason == null || reason.isBlank())) {
+            throw new IllegalArgumentException("거절 시 사유는 필수입니다");
+        }
+        this.reviewer = reviewer;
+        this.verdict = verdict;
+        this.reason = reason;
+        this.decidedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/union/union/domain/review/entity/Verdict.java
+++ b/src/main/java/com/union/union/domain/review/entity/Verdict.java
@@ -1,0 +1,7 @@
+package com.union.union.domain.review.entity;
+
+public enum Verdict {
+    PENDING,
+    ACCEPTED,
+    REJECTED
+}

--- a/src/main/java/com/union/union/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/union/union/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,18 @@
+package com.union.union.domain.review.repository;
+
+import com.union.union.domain.review.entity.Review;
+import com.union.union.domain.review.entity.Verdict;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<Review, UUID> {
+
+    List<Review> findByVerdictOrderByCreatedAtAsc(Verdict verdict);
+
+    Optional<Review> findByVersionId(UUID versionId);
+}

--- a/src/main/java/com/union/union/domain/review/service/ReviewService.java
+++ b/src/main/java/com/union/union/domain/review/service/ReviewService.java
@@ -1,0 +1,87 @@
+package com.union.union.domain.review.service;
+
+import com.union.union.domain.appversion.entity.AppVersion;
+import com.union.union.domain.appversion.repository.AppVersionRepository;
+import com.union.union.domain.review.dto.ReviewDecisionRequestDto;
+import com.union.union.domain.review.dto.ReviewResponseDto;
+import com.union.union.domain.review.entity.Review;
+import com.union.union.domain.review.entity.Verdict;
+import com.union.union.domain.review.repository.ReviewRepository;
+import com.union.union.domain.user.entity.User;
+import com.union.union.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final AppVersionRepository appVersionRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public ReviewResponseDto submitForReview(UUID versionId, UUID publisherId) {
+        AppVersion version = appVersionRepository.findById(versionId)
+                .orElseThrow(() -> new IllegalArgumentException("AppVersion을 찾을 수 없습니다"));
+
+        if (!version.getPublisher().getId().equals(publisherId)) {
+            throw new IllegalArgumentException("본인의 버전만 심사 요청할 수 있습니다");
+        }
+
+        version.submitForReview();
+
+        Review review = Review.builder()
+                .version(version)
+                .build();
+
+        reviewRepository.save(review);
+
+        log.info("심사 요청 완료. reviewId={}, versionId={}", review.getId(), versionId);
+
+        return ReviewResponseDto.from(review);
+    }
+
+    public List<ReviewResponseDto> getPendingReviews() {
+        return reviewRepository.findByVerdictOrderByCreatedAtAsc(Verdict.PENDING)
+                .stream()
+                .map(ReviewResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    public ReviewResponseDto getReview(UUID reviewId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new IllegalArgumentException("Review를 찾을 수 없습니다"));
+        return ReviewResponseDto.from(review);
+    }
+
+    @Transactional
+    public ReviewResponseDto decide(UUID reviewId, ReviewDecisionRequestDto request, UUID adminId) {
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new IllegalArgumentException("Review를 찾을 수 없습니다"));
+
+        User admin = userRepository.findById(adminId)
+                .orElseThrow(() -> new IllegalArgumentException("관리자를 찾을 수 없습니다"));
+
+        review.decide(admin, request.verdict(), request.reason());
+
+        AppVersion version = review.getVersion();
+        if (request.verdict() == Verdict.ACCEPTED) {
+            version.accept();
+            log.info("심사 승인. reviewId={}, versionId={}", reviewId, version.getId());
+        } else {
+            version.reject();
+            log.info("심사 거절. reviewId={}, versionId={}, reason={}", reviewId, version.getId(), request.reason());
+        }
+
+        return ReviewResponseDto.from(review);
+    }
+}


### PR DESCRIPTION
## Summary
- 미니앱 버전 관리 도메인(`AppVersion`) 및 심사 도메인(`Review`) 추가
- 상태 머신: `DRAFT → UPLOADED → IN_REVIEW → ACCEPTED/REJECTED → DEPLOYED`
- 엔티티 도메인 메서드에 Guard 로직 내장 (상태 전이 조건, 테스트 필수, 거절 시 사유 필수)

## API

### AppVersion (`/app-versions`)
| Method | Endpoint | 권한 | 용도 |
|--------|----------|------|------|
| `POST` | `/app-versions` | PUBLISHER | 버전 생성 (DRAFT) + 업로드 SignedURL 반환 |
| `POST` | `/app-versions/{id}/confirm` | PUBLISHER | GCS 파일 검증 → UPLOADED |
| `POST` | `/app-versions/{id}/test-complete` | PUBLISHER | testedAt 기록 |
| `GET` | `/app-versions/{id}/bundle` | 인증 | 번들 다운로드 CDN URL |
| `GET` | `/app-versions/mini-app/{miniAppId}` | PUBLISHER | 미니앱의 버전 목록 |
| `GET` | `/app-versions/{id}` | PUBLISHER/ADMIN | 버전 상세 |

### Review (`/reviews`)
| Method | Endpoint | 권한 | 용도 |
|--------|----------|------|------|
| `POST` | `/reviews` | PUBLISHER | 심사 제출 (UPLOADED → IN_REVIEW) |
| `GET` | `/reviews/pending` | ADMIN | 대기 중 심사 목록 |
| `GET` | `/reviews/{id}` | ADMIN | 심사 상세 |
| `POST` | `/reviews/{id}/decision` | ADMIN | 승인/거절 |

## 상태 전이 Guard
- `confirmUpload()`: DRAFT 상태에서만 가능
- `submitForReview()`: UPLOADED 상태 + testedAt 필수
- `accept()/reject()`: IN_REVIEW 상태에서만 가능
- `Review.decide()`: PENDING 상태에서만, 거절 시 reason 필수