### PR TITLE
fix: 번들 파일 확장자를 .zip에서 .unionapp으로 변경

### DIFF
--- a/src/main/java/com/union/union/domain/appversion/service/AppVersionService.java
+++ b/src/main/java/com/union/union/domain/appversion/service/AppVersionService.java
@@ -58,8 +58,8 @@ public class AppVersionService {
 
         appVersionRepository.save(version);
 
-        String filename = String.format("mini-apps/%s/versions/%s/bundle.zip",
-                miniApp.getId(), version.getId());
+        String filename = String.format("mini-apps/%s/versions/%s/%s-%s.unionapp",
+                miniApp.getId(), version.getId(), miniApp.getName(), request.versionNumber());
         var signedUrlResponse = gcsService.getMiniAppSignedUrl(publisherId, filename);
 
         log.info("AppVersion 생성 (DRAFT). versionId={}, miniAppId={}", version.getId(), miniApp.getId());
@@ -71,8 +71,9 @@ public class AppVersionService {
     public AppVersionResponseDto confirmUpload(UUID versionId, UUID publisherId) {
         AppVersion version = getVersionWithOwnerCheck(versionId, publisherId);
 
-        String objectPath = String.format("mini-apps/%s/versions/%s/bundle.zip",
-                version.getMiniApp().getId(), version.getId());
+        String objectPath = String.format("mini-apps/%s/versions/%s/%s-%s.unionapp",
+                version.getMiniApp().getId(), version.getId(),
+                version.getMiniApp().getName(), version.getVersionNumber());
 
         Blob blob = storage.get(bucketName, objectPath);
         if (blob == null || !blob.exists()) {


### PR DESCRIPTION
## Summary
- GCS 업로드/검증 경로의 파일 확장자를 `.zip` → `.unionapp`으로 변경
- 파일명 형식: `{앱이름}-{버전}.unionapp` (예: `taxipot-1.0.0.unionapp`)