### PR TITLE
fix: 심사 흐름 안정화 및 예외 처리 일관성 정비

### DIFF
--- a/src/main/java/com/union/union/UnionApplication.java
+++ b/src/main/java/com/union/union/UnionApplication.java
@@ -4,8 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @ConfigurationPropertiesScan
 @SpringBootApplication
 public class UnionApplication {

--- a/src/main/java/com/union/union/domain/appversion/entity/AppVersion.java
+++ b/src/main/java/com/union/union/domain/appversion/entity/AppVersion.java
@@ -2,6 +2,7 @@ package com.union.union.domain.appversion.entity;
 
 import com.union.union.domain.miniapp.entity.MiniApp;
 import com.union.union.domain.user.entity.User;
+import com.union.union.global.common.exception.ConflictException;
 import com.union.union.global.common.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -56,7 +57,7 @@ public class AppVersion extends BaseEntity {
 
     public void confirmUpload(String buildFileUrl, Long bundleSize) {
         if (this.status != VersionStatus.DRAFT) {
-            throw new IllegalStateException("DRAFT 상태에서만 업로드를 확정할 수 있습니다");
+            throw new ConflictException("DRAFT 상태에서만 업로드를 확정할 수 있습니다");
         }
         this.buildFileUrl = buildFileUrl;
         this.bundleSize = bundleSize;
@@ -71,31 +72,31 @@ public class AppVersion extends BaseEntity {
 
     public void submitForReview() {
         if (this.status != VersionStatus.UPLOADED) {
-            throw new IllegalStateException("UPLOADED 상태에서만 심사를 요청할 수 있습니다");
+            throw new ConflictException("UPLOADED 상태에서만 심사를 요청할 수 있습니다");
         }
         if (this.testedAt == null) {
-            throw new IllegalStateException("최소 1회 테스트 후 심사를 요청할 수 있습니다");
+            throw new ConflictException("최소 1회 테스트 후 심사를 요청할 수 있습니다");
         }
         this.status = VersionStatus.IN_REVIEW;
     }
 
     public void accept() {
         if (this.status != VersionStatus.IN_REVIEW) {
-            throw new IllegalStateException("IN_REVIEW 상태에서만 승인할 수 있습니다");
+            throw new ConflictException("IN_REVIEW 상태에서만 승인할 수 있습니다");
         }
         this.status = VersionStatus.ACCEPTED;
     }
 
     public void reject() {
         if (this.status != VersionStatus.IN_REVIEW) {
-            throw new IllegalStateException("IN_REVIEW 상태에서만 거절할 수 있습니다");
+            throw new ConflictException("IN_REVIEW 상태에서만 거절할 수 있습니다");
         }
         this.status = VersionStatus.REJECTED;
     }
 
     public void deploy() {
         if (this.status != VersionStatus.ACCEPTED) {
-            throw new IllegalStateException("ACCEPTED 상태에서만 배포할 수 있습니다");
+            throw new ConflictException("ACCEPTED 상태에서만 배포할 수 있습니다");
         }
         this.status = VersionStatus.DEPLOYED;
     }

--- a/src/main/java/com/union/union/domain/appversion/repository/AppVersionRepository.java
+++ b/src/main/java/com/union/union/domain/appversion/repository/AppVersionRepository.java
@@ -2,18 +2,26 @@ package com.union.union.domain.appversion.repository;
 
 import com.union.union.domain.appversion.entity.AppVersion;
 import com.union.union.domain.appversion.entity.VersionStatus;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface AppVersionRepository extends JpaRepository<AppVersion, UUID> {
 
+    @EntityGraph(attributePaths = {"miniApp", "publisher"})
     List<AppVersion> findByMiniAppIdOrderByCreatedAtDesc(Long miniAppId);
 
+    @EntityGraph(attributePaths = {"miniApp", "publisher"})
     List<AppVersion> findByPublisherIdOrderByCreatedAtDesc(UUID publisherId);
 
+    @EntityGraph(attributePaths = {"miniApp", "publisher"})
     List<AppVersion> findByStatus(VersionStatus status);
+
+    @EntityGraph(attributePaths = {"miniApp", "publisher"})
+    Optional<AppVersion> findDetailedById(UUID id);
 }

--- a/src/main/java/com/union/union/domain/appversion/service/AppVersionService.java
+++ b/src/main/java/com/union/union/domain/appversion/service/AppVersionService.java
@@ -11,6 +11,9 @@ import com.union.union.domain.miniapp.entity.MiniApp;
 import com.union.union.domain.miniapp.repository.MiniAppRepository;
 import com.union.union.domain.user.entity.User;
 import com.union.union.domain.user.repository.UserRepository;
+import com.union.union.global.common.exception.ConflictException;
+import com.union.union.global.common.exception.EntityNotFoundException;
+import com.union.union.global.common.exception.UnauthorizedAccessException;
 import com.union.union.global.infra.gcs.GcsService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,13 +43,13 @@ public class AppVersionService {
     @Transactional
     public CreateVersionResponseDto createVersion(CreateVersionRequestDto request, UUID publisherId) {
         User publisher = userRepository.findById(publisherId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다"));
 
-        MiniApp miniApp = miniAppRepository.findById(request.miniAppId())
-                .orElseThrow(() -> new IllegalArgumentException("MiniApp을 찾을 수 없습니다"));
+        MiniApp miniApp = miniAppRepository.findDetailsById(request.miniAppId())
+                .orElseThrow(() -> new EntityNotFoundException("MiniApp을 찾을 수 없습니다"));
 
         if (!miniApp.getPublisher().getId().equals(publisherId)) {
-            throw new IllegalArgumentException("본인의 MiniApp에만 버전을 추가할 수 있습니다");
+            throw new UnauthorizedAccessException("본인의 MiniApp에만 버전을 추가할 수 있습니다");
         }
 
         AppVersion version = AppVersion.builder()
@@ -58,8 +61,8 @@ public class AppVersionService {
 
         appVersionRepository.save(version);
 
-        String filename = String.format("mini-apps/%s/versions/%s/bundle.zip",
-                miniApp.getId(), version.getId());
+        String filename = String.format("mini-apps/%s/versions/%s/%s-%s.unionapp",
+                miniApp.getId(), version.getId(), miniApp.getName(), request.versionNumber());
         var signedUrlResponse = gcsService.getMiniAppSignedUrl(publisherId, filename);
 
         log.info("AppVersion 생성 (DRAFT). versionId={}, miniAppId={}", version.getId(), miniApp.getId());
@@ -71,12 +74,13 @@ public class AppVersionService {
     public AppVersionResponseDto confirmUpload(UUID versionId, UUID publisherId) {
         AppVersion version = getVersionWithOwnerCheck(versionId, publisherId);
 
-        String objectPath = String.format("mini-apps/%s/versions/%s/bundle.zip",
-                version.getMiniApp().getId(), version.getId());
+        String objectPath = String.format("mini-apps/%s/versions/%s/%s-%s.unionapp",
+                version.getMiniApp().getId(), version.getId(),
+                version.getMiniApp().getName(), version.getVersionNumber());
 
         Blob blob = storage.get(bucketName, objectPath);
         if (blob == null || !blob.exists()) {
-            throw new IllegalStateException("GCS에 파일이 존재하지 않습니다. 업로드를 먼저 완료해주세요");
+            throw new ConflictException("GCS에 파일이 존재하지 않습니다. 업로드를 먼저 완료해주세요");
         }
 
         version.confirmUpload(objectPath, blob.getSize());
@@ -97,11 +101,11 @@ public class AppVersionService {
     }
 
     public String getBundleDownloadUrl(UUID versionId) {
-        AppVersion version = appVersionRepository.findById(versionId)
-                .orElseThrow(() -> new IllegalArgumentException("AppVersion을 찾을 수 없습니다"));
+        AppVersion version = appVersionRepository.findDetailedById(versionId)
+                .orElseThrow(() -> new EntityNotFoundException("AppVersion을 찾을 수 없습니다"));
 
         if (version.getBuildFileUrl() == null) {
-            throw new IllegalStateException("아직 업로드되지 않은 버전입니다");
+            throw new ConflictException("아직 업로드되지 않은 버전입니다");
         }
 
         return gcsService.getCdnDownloadUrl(version.getBuildFileUrl());
@@ -115,17 +119,17 @@ public class AppVersionService {
     }
 
     public AppVersionResponseDto getVersion(UUID versionId) {
-        AppVersion version = appVersionRepository.findById(versionId)
-                .orElseThrow(() -> new IllegalArgumentException("AppVersion을 찾을 수 없습니다"));
+        AppVersion version = appVersionRepository.findDetailedById(versionId)
+                .orElseThrow(() -> new EntityNotFoundException("AppVersion을 찾을 수 없습니다"));
         return AppVersionResponseDto.from(version);
     }
 
     private AppVersion getVersionWithOwnerCheck(UUID versionId, UUID publisherId) {
-        AppVersion version = appVersionRepository.findById(versionId)
-                .orElseThrow(() -> new IllegalArgumentException("AppVersion을 찾을 수 없습니다"));
+        AppVersion version = appVersionRepository.findDetailedById(versionId)
+                .orElseThrow(() -> new EntityNotFoundException("AppVersion을 찾을 수 없습니다"));
 
         if (!version.getPublisher().getId().equals(publisherId)) {
-            throw new IllegalArgumentException("본인의 버전만 수정할 수 있습니다");
+            throw new UnauthorizedAccessException("본인의 버전만 수정할 수 있습니다");
         }
 
         return version;

--- a/src/main/java/com/union/union/domain/auth/exception/InvalidEmailFormatException.java
+++ b/src/main/java/com/union/union/domain/auth/exception/InvalidEmailFormatException.java
@@ -1,6 +1,9 @@
 package com.union.union.domain.auth.exception;
 
-public class InvalidEmailFormatException extends RuntimeException {
+import com.union.union.global.common.exception.BadRequestException;
+
+public class InvalidEmailFormatException extends BadRequestException {
+
     public InvalidEmailFormatException(String message) {
         super(message);
     }

--- a/src/main/java/com/union/union/domain/auth/exception/InvalidUniversityDomainException.java
+++ b/src/main/java/com/union/union/domain/auth/exception/InvalidUniversityDomainException.java
@@ -1,6 +1,9 @@
 package com.union.union.domain.auth.exception;
 
-public class InvalidUniversityDomainException extends RuntimeException {
+import com.union.union.global.common.exception.BadRequestException;
+
+public class InvalidUniversityDomainException extends BadRequestException {
+
     public InvalidUniversityDomainException(String message) {
         super(message);
     }

--- a/src/main/java/com/union/union/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/union/union/domain/auth/repository/RefreshTokenRepository.java
@@ -18,5 +18,5 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
 
     @Modifying
     @Query("DELETE FROM RefreshToken rt WHERE rt.revoked = true OR rt.expiresAt < CURRENT_TIMESTAMP")
-    void deleteExpiredAndRevoked();
+    int deleteExpiredAndRevoked();
 }

--- a/src/main/java/com/union/union/domain/auth/scheduler/TokenCleanupScheduler.java
+++ b/src/main/java/com/union/union/domain/auth/scheduler/TokenCleanupScheduler.java
@@ -1,0 +1,23 @@
+package com.union.union.domain.auth.scheduler;
+
+import com.union.union.domain.auth.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TokenCleanupScheduler {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    @Scheduled(cron = "${token-cleanup.refresh-token-cron}")
+    public void cleanupExpiredAndRevokedRefreshTokens() {
+        int deletedCount = refreshTokenRepository.deleteExpiredAndRevoked();
+        log.info("Refresh token cleanup completed. deletedCount={}", deletedCount);
+    }
+}

--- a/src/main/java/com/union/union/domain/auth/service/AuthService.java
+++ b/src/main/java/com/union/union/domain/auth/service/AuthService.java
@@ -6,6 +6,11 @@ import com.union.union.domain.auth.repository.RefreshTokenRepository;
 import com.union.union.domain.auth.store.EmailVerificationStore;
 import com.union.union.domain.user.entity.User;
 import com.union.union.domain.user.repository.UserRepository;
+import com.union.union.global.common.exception.DuplicateEmailException;
+import com.union.union.global.common.exception.EmailNotVerifiedException;
+import com.union.union.global.common.exception.EntityNotFoundException;
+import com.union.union.global.common.exception.InvalidRefreshTokenException;
+import com.union.union.global.common.exception.UnauthorizedAccessException;
 import com.union.union.global.security.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,12 +38,12 @@ public class AuthService {
     public TokenResponseDto signUp(SignUpRequestDto request) {
         // 1. 이메일 중복 확인
         if (userRepository.existsByEmail(request.email())) {
-            throw new IllegalArgumentException("이미 사용 중인 이메일입니다");
+            throw new DuplicateEmailException("이미 사용 중인 이메일입니다");
         }
 
         // 2. 이메일 인증 여부 확인
         if (!verificationStore.isVerified(request.email())) {
-            throw new IllegalArgumentException("이메일 인증이 완료되지 않았습니다");
+            throw new EmailNotVerifiedException("이메일 인증이 완료되지 않았습니다");
         }
 
         // 3. 이메일 도메인으로 대학교 자동 판별
@@ -62,10 +67,18 @@ public class AuthService {
     @Transactional
     public TokenResponseDto login(LoginRequestDto request) {
         User user = userRepository.findByEmail(request.email())
-                .orElseThrow(() -> new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다"));
+                .orElseThrow(() -> new UnauthorizedAccessException("이메일 또는 비밀번호가 올바르지 않습니다"));
 
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {
-            throw new IllegalArgumentException("이메일 또는 비밀번호가 올바르지 않습니다");
+            throw new UnauthorizedAccessException("이메일 또는 비밀번호가 올바르지 않습니다");
+        }
+
+        if (user.getUserStatus() == User.UserStatus.WITHDRAWN) {
+            throw new UnauthorizedAccessException("탈퇴한 계정입니다");
+        }
+
+        if (user.getUserStatus() == User.UserStatus.SUSPENDED) {
+            throw new UnauthorizedAccessException("정지된 계정입니다. 관리자에게 문의하세요");
         }
 
         log.info("로그인 성공. userId={}", user.getId());
@@ -75,18 +88,18 @@ public class AuthService {
     @Transactional
     public TokenResponseDto refresh(RefreshRequestDto request) {
         RefreshToken storedToken = refreshTokenRepository.findByToken(request.refreshToken())
-                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 refresh token입니다"));
+                .orElseThrow(() -> new InvalidRefreshTokenException("유효하지 않은 refresh token입니다"));
 
         // 이미 무효화된 토큰 재사용 → 탈취 감지 → 전체 세션 kill
         if (storedToken.isRevoked()) {
             log.warn("Refresh token 재사용 감지! userId={}. 전체 세션 무효화.", storedToken.getUser().getId());
             refreshTokenRepository.revokeAllByUserId(storedToken.getUser().getId());
-            throw new IllegalArgumentException("보안상 모든 세션이 로그아웃되었습니다. 다시 로그인해주세요.");
+            throw new InvalidRefreshTokenException("보안상 모든 세션이 로그아웃되었습니다. 다시 로그인해주세요.");
         }
 
         if (storedToken.isExpired()) {
             storedToken.revoke();
-            throw new IllegalArgumentException("세션이 만료되었습니다. 다시 로그인해주세요.");
+            throw new InvalidRefreshTokenException("세션이 만료되었습니다. 다시 로그인해주세요.");
         }
 
         // Rotation: 기존 토큰 무효화
@@ -99,6 +112,8 @@ public class AuthService {
 
     @Transactional
     public void logout(UUID userId) {
+        userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다"));
         refreshTokenRepository.revokeAllByUserId(userId);
         log.info("로그아웃. userId={}", userId);
     }

--- a/src/main/java/com/union/union/domain/auth/service/EmailVerificationService.java
+++ b/src/main/java/com/union/union/domain/auth/service/EmailVerificationService.java
@@ -2,6 +2,7 @@ package com.union.union.domain.auth.service;
 
 import com.union.union.domain.auth.store.EmailVerificationStore;
 import com.union.union.domain.university.entity.UniversityDomain;
+import com.union.union.global.common.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -40,10 +41,10 @@ public class EmailVerificationService {
      */
     public boolean verifyCode(String email, String code) {
         String savedCode = verificationStore.get(email)
-                .orElseThrow(() -> new IllegalArgumentException("만료되었거나 유효하지 않은 인증 정보입니다."));
+                .orElseThrow(() -> new BadRequestException("만료되었거나 유효하지 않은 인증 정보입니다."));
 
         if (!savedCode.equals(code)) {
-            throw new IllegalArgumentException("인증번호가 일치하지 않습니다.");
+            throw new BadRequestException("인증번호가 일치하지 않습니다.");
         }
 
         verificationStore.delete(email);

--- a/src/main/java/com/union/union/domain/auth/service/MailService.java
+++ b/src/main/java/com/union/union/domain/auth/service/MailService.java
@@ -2,6 +2,7 @@ package com.union.union.domain.auth.service;
 
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
+import com.union.union.global.common.exception.ExternalServiceException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.javamail.JavaMailSender;
@@ -39,7 +40,7 @@ public class MailService {
             log.info("이메일 발송 성공: {}", to);
         } catch (MessagingException e) {
             log.error("이메일 발송 실패: {}", to, e);
-            throw new RuntimeException("이메일 발송 중 오류가 발생했습니다.");
+            throw new ExternalServiceException("이메일 발송 중 오류가 발생했습니다.");
         }
     }
 }

--- a/src/main/java/com/union/union/domain/miniapp/controller/MiniAppController.java
+++ b/src/main/java/com/union/union/domain/miniapp/controller/MiniAppController.java
@@ -3,8 +3,6 @@ package com.union.union.domain.miniapp.controller;
 import com.union.union.domain.miniapp.dto.MiniAppRegisterRequestDto;
 import com.union.union.domain.miniapp.dto.MiniAppResponseDto;
 import com.union.union.domain.miniapp.service.MiniAppService;
-import com.union.union.global.infra.gcs.GcsService;
-import com.union.union.global.infra.gcs.dto.GcsSignedUrlResponseDto;
 import com.union.union.global.security.jwt.JwtUserPrincipal;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +22,6 @@ import java.util.UUID;
 public class MiniAppController {
 
     private final MiniAppService miniAppService;
-    private final GcsService gcsService;
 
     @PostMapping
     @PreAuthorize("hasRole('PUBLISHER')")
@@ -73,60 +70,4 @@ public class MiniAppController {
                 .build();
     }
 
-    @PatchMapping("/{id}/approve")
-    @PreAuthorize("hasRole('ADMIN')")
-    public ResponseEntity<MiniAppResponseDto> approve(@PathVariable Long id) {
-        MiniAppResponseDto response = miniAppService.approve(id);
-        return ResponseEntity.ok(response);
-    }
-
-    @PostMapping("/signed-url")
-    @PreAuthorize("hasRole('PUBLISHER')")
-    public ResponseEntity<GcsSignedUrlResponseDto> getSignedUrl(
-            @RequestParam String filename,
-            @AuthenticationPrincipal JwtUserPrincipal principal
-    ) {
-        GcsSignedUrlResponseDto response = gcsService.getMiniAppSignedUrl(principal.userId(), filename);
-        return ResponseEntity.ok(response);
-    }
-
-    @GetMapping("/{id}/download-url")
-    public ResponseEntity<java.util.Map<String, String>> getDownloadUrl(
-            @PathVariable Long id,
-            @AuthenticationPrincipal JwtUserPrincipal principal
-    ) {
-        UUID userId = principal != null ? principal.userId() : null;
-        String launchUrl = miniAppService.getLaunchUrl(id, userId);
-
-        // launchUrl이 GCS 경로를 포함하는 경우 CDN Signed URL로 변환
-        String cdnUrl = gcsService.getCdnDownloadUrl(extractObjectPath(launchUrl));
-        return ResponseEntity.ok(java.util.Map.of("downloadUrl", cdnUrl));
-    }
-
-    @GetMapping("/{id}/test-url")
-    @PreAuthorize("hasRole('PUBLISHER')")
-    public ResponseEntity<java.util.Map<String, String>> getTestUrl(
-            @PathVariable Long id,
-            @AuthenticationPrincipal JwtUserPrincipal principal
-    ) {
-        // 1. 서비스 로직 호출 (권한 체크 및 상태 변경)
-        String launchUrl = miniAppService.getTestLaunchUrl(id, principal.userId());
-
-        // 2. GCS 경로 추출 및 Signed URL 생성
-        String objectPath = extractObjectPath(launchUrl);
-        String cdnUrl = gcsService.getCdnDownloadUrl(objectPath);
-
-        return ResponseEntity.ok(java.util.Map.of("testUrl", cdnUrl));
-    }
-
-    private String extractObjectPath(String url) {
-        // GCS URL 또는 상대 경로에서 오브젝트 경로 추출
-        if (url.contains("storage.googleapis.com/")) {
-            return url.substring(url.indexOf("storage.googleapis.com/") + "storage.googleapis.com/".length());
-        }
-        if (url.startsWith("mini-apps/")) {
-            return url;
-        }
-        return url.startsWith("/") ? url.substring(1) : url;
-    }
 }

--- a/src/main/java/com/union/union/domain/miniapp/entity/MiniApp.java
+++ b/src/main/java/com/union/union/domain/miniapp/entity/MiniApp.java
@@ -56,11 +56,7 @@ public class MiniApp extends BaseEntity {
         this.status = MiniAppStatus.APPROVED;
     }
 
-    public void test() {
-        this.status = MiniAppStatus.TESTING;
-    }
-
-    public void reject() {
+public void reject() {
         this.status = MiniAppStatus.REJECTED;
     }
 }

--- a/src/main/java/com/union/union/domain/miniapp/entity/MiniAppStatus.java
+++ b/src/main/java/com/union/union/domain/miniapp/entity/MiniAppStatus.java
@@ -2,7 +2,6 @@ package com.union.union.domain.miniapp.entity;
 
 public enum MiniAppStatus {
     PENDING,
-    TESTING,
     APPROVED,
     REJECTED
 }

--- a/src/main/java/com/union/union/domain/miniapp/repository/MiniAppRepository.java
+++ b/src/main/java/com/union/union/domain/miniapp/repository/MiniAppRepository.java
@@ -3,6 +3,7 @@ package com.union.union.domain.miniapp.repository;
 import com.union.union.domain.miniapp.entity.MiniApp;
 import com.union.union.domain.miniapp.entity.MiniAppStatus;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,33 +14,42 @@ import java.util.UUID;
 
 @Repository
 public interface MiniAppRepository extends JpaRepository<MiniApp, Long> {
-    
+
+    @EntityGraph(attributePaths = {"publisher", "university"})
     @Query("SELECT m FROM MiniApp m WHERE m.status = :status AND (:universityId IS NULL OR m.university.id = :universityId)")
     List<MiniApp> findByStatusAndUniversityId(@Param("status") MiniAppStatus status, @Param("universityId") Long universityId);
 
+    @EntityGraph(attributePaths = {"publisher", "university"})
     @Query("SELECT m FROM MiniApp m " +
            "LEFT JOIN MiniAppUsage u ON m.id = u.miniAppId " +
-           "WHERE m.status = com.union.union.domain.miniapp.entity.MiniAppStatus.APPROVED " +
+           "WHERE m.status = :status " +
            "GROUP BY m.id " +
            "ORDER BY COUNT(u) DESC")
-    List<MiniApp> findPopularMiniApps(Pageable pageable);
+    List<MiniApp> findPopularMiniApps(@Param("status") MiniAppStatus status, Pageable pageable);
 
+    @EntityGraph(attributePaths = {"publisher", "university"})
     List<MiniApp> findByPublisherId(UUID publisherId);
 
+    @EntityGraph(attributePaths = {"publisher", "university"})
     @Query("SELECT m FROM MiniApp m " +
            "JOIN MiniAppUsage u ON m.id = u.miniAppId " +
            "JOIN User user ON u.userId = user.id " +
            "WHERE user.universityName = :universityName " +
-           "AND m.status = 'APPROVED' " +
+           "AND m.status = :status " +
            "GROUP BY m.id " +
            "ORDER BY COUNT(u) DESC")
-    List<MiniApp> findRecommendedByUniversity(@Param("universityName") String universityName, Pageable pageable);
+    List<MiniApp> findRecommendedByUniversity(@Param("universityName") String universityName, @Param("status") MiniAppStatus status, Pageable pageable);
 
+    @EntityGraph(attributePaths = {"publisher", "university"})
     @Query("SELECT m FROM MiniApp m " +
            "JOIN MiniAppUsage u ON m.id = u.miniAppId " +
            "WHERE u.userId = :userId " +
-           "AND m.status = 'APPROVED' " +
+           "AND m.status = :status " +
            "GROUP BY m.id " +
            "ORDER BY MAX(u.timestamp) DESC")
-    List<MiniApp> findRecentByUser(@Param("userId") UUID userId, Pageable pageable);
+    List<MiniApp> findRecentByUser(@Param("userId") UUID userId, @Param("status") MiniAppStatus status, Pageable pageable);
+
+    @EntityGraph(attributePaths = {"publisher", "university"})
+    @Query("SELECT m FROM MiniApp m WHERE m.id = :id")
+    java.util.Optional<MiniApp> findDetailsById(@Param("id") Long id);
 }

--- a/src/main/java/com/union/union/domain/miniapp/service/MiniAppService.java
+++ b/src/main/java/com/union/union/domain/miniapp/service/MiniAppService.java
@@ -13,6 +13,8 @@ import com.union.union.domain.university.entity.UniversityDomain;
 import com.union.union.domain.university.repository.UniversityDomainRepository;
 import com.union.union.domain.user.entity.User;
 import com.union.union.domain.user.repository.UserRepository;
+import com.union.union.global.common.exception.EntityNotFoundException;
+import com.union.union.global.common.exception.UnauthorizedAccessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
@@ -41,16 +43,16 @@ public class MiniAppService {
     @CacheEvict(value = "miniApps", allEntries = true)
     public MiniAppResponseDto register(MiniAppRegisterRequestDto request, UUID userId) {
         User publisher = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다"));
 
         if (publisher.getRole() != User.Role.ROLE_PUBLISHER) {
-            throw new IllegalArgumentException("MiniApp을 등록할 권한이 없습니다 (PUBLISHER 권한 필요)");
+            throw new UnauthorizedAccessException("MiniApp을 등록할 권한이 없습니다 (PUBLISHER 권한 필요)");
         }
 
         UniversityDomain university = null;
         if (request.universityId() != null) {
             university = universityDomainRepository.findById(request.universityId())
-                    .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 대학교입니다"));
+                    .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 대학교입니다"));
         }
 
         MiniApp miniApp = MiniApp.builder()
@@ -79,7 +81,7 @@ public class MiniAppService {
 
     @Cacheable(value = "popularMiniApps", key = "#limit")
     public List<MiniAppResponseDto> getPopularMiniApps(int limit) {
-        return miniAppRepository.findPopularMiniApps(PageRequest.of(0, limit))
+        return miniAppRepository.findPopularMiniApps(MiniAppStatus.APPROVED, PageRequest.of(0, limit))
                 .stream()
                 .map(MiniAppResponseDto::from)
                 .collect(Collectors.toList());
@@ -87,14 +89,14 @@ public class MiniAppService {
 
     public List<MiniAppResponseDto> getRecommendedMiniApps(UUID userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다"));
 
         // 1. 같은 대학 인기 앱 (Top 5)
         List<MiniApp> universityPopular = miniAppRepository.findRecommendedByUniversity(
-                user.getUniversityName(), PageRequest.of(0, 5));
+                user.getUniversityName(), MiniAppStatus.APPROVED, PageRequest.of(0, 5));
 
         // 2. 내가 최근에 사용한 앱 (Top 5)
-        List<MiniApp> myRecent = miniAppRepository.findRecentByUser(userId, PageRequest.of(0, 5));
+        List<MiniApp> myRecent = miniAppRepository.findRecentByUser(userId, MiniAppStatus.APPROVED, PageRequest.of(0, 5));
 
         // 3. 중복 제거 및 결합
         List<MiniApp> combined = new java.util.ArrayList<>(universityPopular);
@@ -106,7 +108,7 @@ public class MiniAppService {
 
         // 4. 결과가 부족하면 글로벌 인기 앱 추가
         if (combined.size() < 5) {
-            List<MiniApp> globalPopular = miniAppRepository.findPopularMiniApps(PageRequest.of(0, 10));
+            List<MiniApp> globalPopular = miniAppRepository.findPopularMiniApps(MiniAppStatus.APPROVED, PageRequest.of(0, 10));
             for (MiniApp popular : globalPopular) {
                 if (!combined.contains(popular)) {
                     combined.add(popular);
@@ -137,24 +139,24 @@ public class MiniAppService {
     }
 
     public String getLaunchUrl(Long id, UUID userId) {
-        MiniApp miniApp = miniAppRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("MiniApp을 찾을 수 없습니다"));
+        MiniApp miniApp = miniAppRepository.findDetailsById(id)
+                .orElseThrow(() -> new EntityNotFoundException("MiniApp을 찾을 수 없습니다"));
 
         if (miniApp.getStatus() != MiniAppStatus.APPROVED) {
-            throw new IllegalArgumentException("승인되지 않은 MiniApp입니다");
+            throw new UnauthorizedAccessException("승인되지 않은 MiniApp입니다");
         }
 
         // 대학교 제한이 있는 경우 권한 체크
         if (miniApp.getUniversity() != null) {
             if (userId == null) {
-                throw new IllegalArgumentException("해당 대학교 전용 MiniApp입니다. 로그인이 필요합니다.");
+                throw new UnauthorizedAccessException("해당 대학교 전용 MiniApp입니다. 로그인이 필요합니다.");
             }
-            
+
             User user = userRepository.findById(userId)
-                    .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다"));
+                    .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다"));
 
             if (!miniApp.getUniversity().getUniversityName().equals(user.getUniversityName())) {
-                throw new IllegalArgumentException("해당 대학교 학생만 접근 가능한 MiniApp입니다");
+                throw new UnauthorizedAccessException("해당 대학교 학생만 접근 가능한 MiniApp입니다");
             }
         }
 
@@ -166,32 +168,4 @@ public class MiniAppService {
         return miniApp.getLaunchUrl();
     }
 
-    @Transactional
-    @CacheEvict(value = "miniApps", allEntries = true)
-    public MiniAppResponseDto approve(Long id) {
-        MiniApp miniApp = miniAppRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("MiniApp을 찾을 수 없습니다"));
-
-        miniApp.approve();
-        log.info("MiniApp 승인 완료. id={}, name={}", miniApp.getId(), miniApp.getName());
-
-        return MiniAppResponseDto.from(miniApp);
-    }
-
-    @Transactional
-    public String getTestLaunchUrl(Long id, UUID userId) {
-        MiniApp miniApp = miniAppRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("MiniApp을 찾을 수 없습니다"));
-
-        // 권한 체크: 퍼블리셔 본인인지 확인
-        if (!miniApp.getPublisher().getId().equals(userId)) {
-            throw new IllegalArgumentException("본인의 MiniApp만 테스트할 수 있습니다");
-        }
-
-        // 상태를 TESTING으로 변경 (기존 회의 내용 반영)
-        miniApp.test();
-        log.info("MiniApp 테스트 시작. id={}, name={}, status={}", miniApp.getId(), miniApp.getName(), miniApp.getStatus());
-
-        return miniApp.getLaunchUrl();
-    }
 }

--- a/src/main/java/com/union/union/domain/review/entity/Review.java
+++ b/src/main/java/com/union/union/domain/review/entity/Review.java
@@ -3,6 +3,8 @@ package com.union.union.domain.review.entity;
 import com.union.union.domain.appversion.entity.AppVersion;
 import com.union.union.domain.user.entity.User;
 import com.union.union.global.common.entity.BaseEntity;
+import com.union.union.global.common.exception.BadRequestException;
+import com.union.union.global.common.exception.ConflictException;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -12,7 +14,9 @@ import java.util.UUID;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "reviews")
+@Table(name = "reviews", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_review_version", columnNames = {"version_id"})
+})
 public class Review extends BaseEntity {
 
     @Id
@@ -45,10 +49,10 @@ public class Review extends BaseEntity {
 
     public void decide(User reviewer, Verdict verdict, String reason) {
         if (this.verdict != Verdict.PENDING) {
-            throw new IllegalStateException("이미 처리된 심사입니다");
+            throw new ConflictException("이미 처리된 심사입니다");
         }
         if (verdict == Verdict.REJECTED && (reason == null || reason.isBlank())) {
-            throw new IllegalArgumentException("거절 시 사유는 필수입니다");
+            throw new BadRequestException("거절 시 사유는 필수입니다");
         }
         this.reviewer = reviewer;
         this.verdict = verdict;

--- a/src/main/java/com/union/union/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/union/union/domain/review/repository/ReviewRepository.java
@@ -2,6 +2,7 @@ package com.union.union.domain.review.repository;
 
 import com.union.union.domain.review.entity.Review;
 import com.union.union.domain.review.entity.Verdict;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,7 +13,13 @@ import java.util.UUID;
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, UUID> {
 
+    @EntityGraph(attributePaths = {"version", "version.miniApp", "version.publisher", "reviewer"})
     List<Review> findByVerdictOrderByCreatedAtAsc(Verdict verdict);
 
     Optional<Review> findByVersionId(UUID versionId);
+
+    boolean existsByVersionIdAndVerdict(UUID versionId, Verdict verdict);
+
+    @EntityGraph(attributePaths = {"version", "version.miniApp", "version.publisher", "reviewer"})
+    Optional<Review> findDetailedById(UUID id);
 }

--- a/src/main/java/com/union/union/domain/review/service/ReviewService.java
+++ b/src/main/java/com/union/union/domain/review/service/ReviewService.java
@@ -9,6 +9,9 @@ import com.union.union.domain.review.entity.Verdict;
 import com.union.union.domain.review.repository.ReviewRepository;
 import com.union.union.domain.user.entity.User;
 import com.union.union.domain.user.repository.UserRepository;
+import com.union.union.global.common.exception.ConflictException;
+import com.union.union.global.common.exception.EntityNotFoundException;
+import com.union.union.global.common.exception.UnauthorizedAccessException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -30,11 +33,15 @@ public class ReviewService {
 
     @Transactional
     public ReviewResponseDto submitForReview(UUID versionId, UUID publisherId) {
-        AppVersion version = appVersionRepository.findById(versionId)
-                .orElseThrow(() -> new IllegalArgumentException("AppVersion을 찾을 수 없습니다"));
+        AppVersion version = appVersionRepository.findDetailedById(versionId)
+                .orElseThrow(() -> new EntityNotFoundException("AppVersion을 찾을 수 없습니다"));
 
         if (!version.getPublisher().getId().equals(publisherId)) {
-            throw new IllegalArgumentException("본인의 버전만 심사 요청할 수 있습니다");
+            throw new UnauthorizedAccessException("본인의 버전만 심사 요청할 수 있습니다");
+        }
+
+        if (reviewRepository.existsByVersionIdAndVerdict(versionId, Verdict.PENDING)) {
+            throw new ConflictException("이미 심사가 진행 중인 버전입니다");
         }
 
         version.submitForReview();
@@ -58,18 +65,18 @@ public class ReviewService {
     }
 
     public ReviewResponseDto getReview(UUID reviewId) {
-        Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new IllegalArgumentException("Review를 찾을 수 없습니다"));
+        Review review = reviewRepository.findDetailedById(reviewId)
+                .orElseThrow(() -> new EntityNotFoundException("Review를 찾을 수 없습니다"));
         return ReviewResponseDto.from(review);
     }
 
     @Transactional
     public ReviewResponseDto decide(UUID reviewId, ReviewDecisionRequestDto request, UUID adminId) {
-        Review review = reviewRepository.findById(reviewId)
-                .orElseThrow(() -> new IllegalArgumentException("Review를 찾을 수 없습니다"));
+        Review review = reviewRepository.findDetailedById(reviewId)
+                .orElseThrow(() -> new EntityNotFoundException("Review를 찾을 수 없습니다"));
 
         User admin = userRepository.findById(adminId)
-                .orElseThrow(() -> new IllegalArgumentException("관리자를 찾을 수 없습니다"));
+                .orElseThrow(() -> new EntityNotFoundException("관리자를 찾을 수 없습니다"));
 
         review.decide(admin, request.verdict(), request.reason());
 

--- a/src/main/java/com/union/union/domain/university/service/UniversityService.java
+++ b/src/main/java/com/union/union/domain/university/service/UniversityService.java
@@ -2,6 +2,7 @@ package com.union.union.domain.university.service;
 
 import com.union.union.domain.university.dto.ExternalUniversityResponseDto;
 import com.union.union.domain.university.dto.UniversityResponseDto;
+import com.union.union.global.common.exception.ExternalServiceException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 
@@ -67,8 +68,7 @@ public class UniversityService {
 
         } catch (Exception e) {
             log.error("커리어넷 학교 검색 API 호출 중 오류 발생. keyword: {}", keyword, e);
-            // 실무에서는 사용자 전용 Custom Exception 클래스를 만들어서 GlobalExceptionHandler로 잡아냅니다.
-            throw new RuntimeException("대학교 목록을 불러오는 중 오류가 발생했습니다.");
+            throw new ExternalServiceException("대학교 목록을 불러오는 중 오류가 발생했습니다.");
         }
     }
 }

--- a/src/main/java/com/union/union/domain/user/service/UserService.java
+++ b/src/main/java/com/union/union/domain/user/service/UserService.java
@@ -28,6 +28,6 @@ public class UserService {
     @Transactional
     public void deleteUser(UUID id) {
         User user = getUser(id);
-        userRepository.delete(user);
+        user.withdraw();
     }
 }

--- a/src/main/java/com/union/union/global/common/exception/BadRequestException.java
+++ b/src/main/java/com/union/union/global/common/exception/BadRequestException.java
@@ -1,0 +1,10 @@
+package com.union.union.global.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class BadRequestException extends BusinessException {
+
+    public BadRequestException(String message) {
+        super(HttpStatus.BAD_REQUEST, "BAD_REQUEST", message);
+    }
+}

--- a/src/main/java/com/union/union/global/common/exception/BusinessException.java
+++ b/src/main/java/com/union/union/global/common/exception/BusinessException.java
@@ -1,0 +1,23 @@
+package com.union.union.global.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public abstract class BusinessException extends RuntimeException {
+
+    private final HttpStatus status;
+    private final String code;
+
+    protected BusinessException(HttpStatus status, String code, String message) {
+        super(message);
+        this.status = status;
+        this.code = code;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/src/main/java/com/union/union/global/common/exception/ConflictException.java
+++ b/src/main/java/com/union/union/global/common/exception/ConflictException.java
@@ -1,0 +1,10 @@
+package com.union.union.global.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ConflictException extends BusinessException {
+
+    public ConflictException(String message) {
+        super(HttpStatus.CONFLICT, "CONFLICT", message);
+    }
+}

--- a/src/main/java/com/union/union/global/common/exception/DuplicateEmailException.java
+++ b/src/main/java/com/union/union/global/common/exception/DuplicateEmailException.java
@@ -1,0 +1,10 @@
+package com.union.union.global.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class DuplicateEmailException extends BusinessException {
+
+    public DuplicateEmailException(String message) {
+        super(HttpStatus.CONFLICT, "DUPLICATE_EMAIL", message);
+    }
+}

--- a/src/main/java/com/union/union/global/common/exception/EmailNotVerifiedException.java
+++ b/src/main/java/com/union/union/global/common/exception/EmailNotVerifiedException.java
@@ -1,0 +1,10 @@
+package com.union.union.global.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class EmailNotVerifiedException extends BusinessException {
+
+    public EmailNotVerifiedException(String message) {
+        super(HttpStatus.FORBIDDEN, "EMAIL_NOT_VERIFIED", message);
+    }
+}

--- a/src/main/java/com/union/union/global/common/exception/EntityNotFoundException.java
+++ b/src/main/java/com/union/union/global/common/exception/EntityNotFoundException.java
@@ -1,0 +1,10 @@
+package com.union.union.global.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class EntityNotFoundException extends BusinessException {
+
+    public EntityNotFoundException(String message) {
+        super(HttpStatus.NOT_FOUND, "ENTITY_NOT_FOUND", message);
+    }
+}

--- a/src/main/java/com/union/union/global/common/exception/ErrorResponse.java
+++ b/src/main/java/com/union/union/global/common/exception/ErrorResponse.java
@@ -1,0 +1,25 @@
+package com.union.union.global.common.exception;
+
+import java.time.LocalDateTime;
+
+public record ErrorResponse(
+        int status,
+        String error,
+        String code,
+        String message,
+        String timestamp
+) {
+    public static ErrorResponse from(BusinessException exception) {
+        return new ErrorResponse(
+                exception.getStatus().value(),
+                exception.getStatus().getReasonPhrase(),
+                exception.getCode(),
+                exception.getMessage(),
+                LocalDateTime.now().toString()
+        );
+    }
+
+    public static ErrorResponse of(int status, String error, String code, String message) {
+        return new ErrorResponse(status, error, code, message, LocalDateTime.now().toString());
+    }
+}

--- a/src/main/java/com/union/union/global/common/exception/ExternalServiceException.java
+++ b/src/main/java/com/union/union/global/common/exception/ExternalServiceException.java
@@ -1,0 +1,10 @@
+package com.union.union.global.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ExternalServiceException extends BusinessException {
+
+    public ExternalServiceException(String message) {
+        super(HttpStatus.BAD_GATEWAY, "EXTERNAL_SERVICE_ERROR", message);
+    }
+}

--- a/src/main/java/com/union/union/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/union/union/global/common/exception/GlobalExceptionHandler.java
@@ -1,57 +1,47 @@
 package com.union.union.global.common.exception;
 
-import com.union.union.domain.auth.exception.InvalidEmailFormatException;
-import com.union.union.domain.auth.exception.InvalidUniversityDomainException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import java.time.LocalDateTime;
-import java.util.Map;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<Map<String, Object>> handleIllegalArgument(IllegalArgumentException e) {
-        return buildResponse(HttpStatus.BAD_REQUEST, e.getMessage());
-    }
-
-    @ExceptionHandler(InvalidEmailFormatException.class)
-    public ResponseEntity<Map<String, Object>> handleInvalidEmailFormat(InvalidEmailFormatException e) {
-        return buildResponse(HttpStatus.BAD_REQUEST, e.getMessage());
-    }
-
-    @ExceptionHandler(InvalidUniversityDomainException.class)
-    public ResponseEntity<Map<String, Object>> handleInvalidUniversityDomain(InvalidUniversityDomainException e) {
-        return buildResponse(HttpStatus.BAD_REQUEST, e.getMessage());
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        return ResponseEntity.status(e.getStatus()).body(ErrorResponse.from(e));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<Map<String, Object>> handleValidation(MethodArgumentNotValidException e) {
+    public ResponseEntity<ErrorResponse> handleValidation(MethodArgumentNotValidException e) {
         String message = e.getBindingResult().getFieldErrors().stream()
                 .map(error -> error.getField() + ": " + error.getDefaultMessage())
                 .findFirst()
                 .orElse("입력값이 올바르지 않습니다");
-        return buildResponse(HttpStatus.BAD_REQUEST, message);
+        return ResponseEntity.badRequest()
+                .body(ErrorResponse.of(HttpStatus.BAD_REQUEST.value(), HttpStatus.BAD_REQUEST.getReasonPhrase(),
+                        "VALIDATION_ERROR", message));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDenied(AccessDeniedException e) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(ErrorResponse.of(HttpStatus.FORBIDDEN.value(), HttpStatus.FORBIDDEN.getReasonPhrase(),
+                        "ACCESS_DENIED", "접근 권한이 없습니다"));
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<Map<String, Object>> handleException(Exception e) {
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
         log.error("Unhandled exception", e);
-        return buildResponse(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다");
-    }
-
-    private ResponseEntity<Map<String, Object>> buildResponse(HttpStatus status, String message) {
-        return ResponseEntity.status(status).body(Map.of(
-                "status", status.value(),
-                "error", status.getReasonPhrase(),
-                "message", message,
-                "timestamp", LocalDateTime.now().toString()
-        ));
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ErrorResponse.of(HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                        HttpStatus.INTERNAL_SERVER_ERROR.getReasonPhrase(),
+                        "INTERNAL_SERVER_ERROR",
+                        "서버 내부 오류가 발생했습니다"));
     }
 }

--- a/src/main/java/com/union/union/global/common/exception/InvalidRefreshTokenException.java
+++ b/src/main/java/com/union/union/global/common/exception/InvalidRefreshTokenException.java
@@ -1,0 +1,10 @@
+package com.union.union.global.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidRefreshTokenException extends BusinessException {
+
+    public InvalidRefreshTokenException(String message) {
+        super(HttpStatus.UNAUTHORIZED, "INVALID_REFRESH_TOKEN", message);
+    }
+}

--- a/src/main/java/com/union/union/global/common/exception/UnauthorizedAccessException.java
+++ b/src/main/java/com/union/union/global/common/exception/UnauthorizedAccessException.java
@@ -1,0 +1,10 @@
+package com.union.union.global.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class UnauthorizedAccessException extends BusinessException {
+
+    public UnauthorizedAccessException(String message) {
+        super(HttpStatus.FORBIDDEN, "UNAUTHORIZED_ACCESS", message);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,3 +63,23 @@ cdn:
   base-url: ${CDN_BASE_URL}
   key-name: ${CDN_KEY_NAME}
   key-value: ${CDN_KEY_VALUE}
+
+cors:
+  allowed-origins: ${CORS_ALLOWED_ORIGINS:}
+
+rate-limit:
+  login:
+    max-requests: 10
+    window-seconds: 60
+  signup:
+    max-requests: 5
+    window-seconds: 60
+  email-send:
+    max-requests: 3
+    window-seconds: 60
+  email-verify:
+    max-requests: 5
+    window-seconds: 60
+
+token-cleanup:
+  refresh-token-cron: ${REFRESH_TOKEN_CLEANUP_CRON:0 0 4 * * *}


### PR DESCRIPTION
## 작업 개요
이번 변경은 리뷰/배포 흐름에서 누적되던 운영 리스크를 줄이고, API 응답의 일관성과 조회 성능을 함께 정리하는 데 목적이 있습니다.

## 주요 변경 사항
### 1. RefreshToken 정리 스케줄러 추가
- 만료되었거나 폐기된 RefreshToken을 주기적으로 정리하는 스케줄러를 추가했습니다.
- 애플리케이션 레벨에서 스케줄링을 활성화하고, cron 설정을 application 설정으로 분리했습니다.

### 2. 커스텀 예외 체계 도입 및 응답 포맷 정리
- BusinessException 기반 예외 계층을 도입해 도메인별 의미가 드러나는 예외를 사용하도록 변경했습니다.
- GlobalExceptionHandler에서 HTTP 상태 코드와 에러 코드가 일관되게 내려가도록 정리했습니다.
- Auth, MiniApp, AppVersion, Review, University 흐름의 직접적인 IllegalArgumentException / IllegalStateException 사용을 정리했습니다.

### 3. N+1 쿼리 완화
- MiniApp, AppVersion, Review 조회 경로에 EntityGraph 기반 로딩을 적용했습니다.
- DTO 변환 시 LAZY 연관 객체 접근으로 발생하던 추가 쿼리를 줄이도록 repository 메서드를 보강했습니다.

### 4. 현재 서비스 구조와 컨트롤러 흐름 정합성 보완
- MiniAppController가 더 이상 존재하지 않는 서비스 메서드를 호출하지 않도록 현재 서비스 구조에 맞게 정리했습니다.
- 관련 리뷰/런치 흐름과 맞물린 부분도 함께 정리해 브랜치 단위로 일관되게 동작하도록 맞췄습니다.

## 검증 내역
- `./gradlew compileJava` 통과
- `./gradlew test`
  - 로컬 환경에서는 `DB_URL`이 주입되지 않아 Spring context 로딩 단계에서 실패했습니다.
  - 확인된 메시지: `Driver org.postgresql.Driver claims to not accept jdbcUrl, ${DB_URL}`

## 참고 사항
- Publisher 엔티티 구조 변경은 현재 요청 범위에서 제외했습니다.
- 따라서 Publisher 엔티티 이중 ID 정리 이슈는 이번 PR에 포함하지 않았습니다.