### PR TITLE
feat(analytics): Analytics 이벤트 수집 도메인 및 REST API 구현

### DIFF
--- a/src/main/java/com/union/union/domain/analytics/controller/AnalyticsController.java
+++ b/src/main/java/com/union/union/domain/analytics/controller/AnalyticsController.java
@@ -1,0 +1,204 @@
+package com.union.union.domain.analytics.controller;
+
+import com.union.union.domain.analytics.dto.request.EventBatchRequestDto;
+import com.union.union.domain.analytics.dto.response.AnalyticsEventPageDto;
+import com.union.union.domain.analytics.dto.response.AppAnalyticsSummaryDto;
+import com.union.union.domain.analytics.dto.response.BatchIngestResponseDto;
+import com.union.union.domain.analytics.service.AnalyticsIngestService;
+import com.union.union.domain.analytics.service.AnalyticsQueryService;
+import com.union.union.global.security.jwt.JwtUserPrincipal;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+/**
+ * Analytics REST API 컨트롤러.
+ *
+ * <h3>엔드포인트 분류</h3>
+ * <table>
+ *   <tr><th>메서드</th><th>경로</th><th>호출자</th><th>인증</th></tr>
+ *   <tr><td>POST</td><td>/api/v1/analytics/events</td><td>iOS/Android 네이티브</td><td>User JWT</td></tr>
+ *   <tr><td>GET</td><td>/api/v1/analytics/apps/{appId}/summary</td><td>퍼블리셔 대시보드</td><td>Internal JWT (PUBLISHER|ADMIN)</td></tr>
+ *   <tr><td>GET</td><td>/api/v1/analytics/apps/{appId}/events</td><td>퍼블리셔 대시보드</td><td>Internal JWT (PUBLISHER|ADMIN)</td></tr>
+ * </table>
+ *
+ * <h3>보안</h3>
+ * <ul>
+ *   <li>{@code POST /events}: 인증된 사용자라면 누구나 호출 가능 (앱 사용 중인 유저 = ROLE_USER)</li>
+ *   <li>Query 엔드포인트: ROLE_PUBLISHER 또는 ROLE_ADMIN 만 접근 가능</li>
+ *   <li>PUBLISHER 는 자신의 워크스페이스 미니앱만 조회 가능 (서비스 레이어에서 강제)</li>
+ * </ul>
+ */
+@RestController
+@RequestMapping("/api/v1/analytics")
+@RequiredArgsConstructor
+@Validated
+public class AnalyticsController {
+
+    private final AnalyticsIngestService ingestService;
+    private final AnalyticsQueryService  queryService;
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Ingest — 네이티브 앱에서 호출
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * 이벤트 배치 수신.
+     *
+     * <p>네이티브 iOS/Android 앱이 이벤트를 최대 100개씩 배치로 전송한다.
+     *
+     * <h4>헤더</h4>
+     * <ul>
+     *   <li>{@code Authorization: Bearer <user_access_token>} — 필수</li>
+     *   <li>{@code X-Request-ID: <UUID>} — 멱등성 보장용 (필수)</li>
+     *   <li>{@code X-Union-AppId: com.union.soccer} — 미니앱 식별 (필수)</li>
+     *   <li>{@code X-Union-SDKVersion: 1.0.0} — 버전 추적용 (선택)</li>
+     * </ul>
+     *
+     * <h4>응답 코드</h4>
+     * <ul>
+     *   <li>200: 전체 처리 성공</li>
+     *   <li>207: 일부 이벤트 거절 ({@code rejected > 0})</li>
+     *   <li>400: 요청 형식 오류</li>
+     *   <li>401: 인증 실패 (토큰 만료 → 네이티브가 갱신 후 재시도)</li>
+     *   <li>404: 미등록 또는 미승인 appId</li>
+     * </ul>
+     */
+    @PostMapping("/events")
+    public ResponseEntity<BatchIngestResponseDto> ingestEvents(
+        @RequestHeader("X-Request-ID")
+        @NotBlank(message = "X-Request-ID header is required")
+        String requestId,
+
+        @RequestHeader("X-Union-AppId")
+        @NotBlank(message = "X-Union-AppId header is required")
+        String appId,
+
+        @RequestHeader(value = "X-Union-SDKVersion", required = false, defaultValue = "unknown")
+        String sdkVersion,
+
+        @Valid @RequestBody EventBatchRequestDto batch,
+
+        @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        BatchIngestResponseDto result = ingestService.ingest(requestId, appId, batch, principal);
+
+        // 일부 이벤트 거절 시 207 Multi-Status
+        HttpStatus status = result.rejected() > 0 ? HttpStatus.MULTI_STATUS : HttpStatus.OK;
+        return ResponseEntity.status(status).body(result);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Query — 퍼블리셔 대시보드에서 호출
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * 미니앱 Analytics 요약 조회.
+     *
+     * <p>기간 집계 데이터를 반환한다. 결과는 5분간 Redis 캐싱됨.
+     *
+     * @param appId 미니앱 식별자 (e.g. "com.union.soccer")
+     * @param from  조회 시작일 (ISO 8601, 기본값: 오늘 기준 30일 전)
+     * @param to    조회 종료일 (ISO 8601, 기본값: 오늘)
+     */
+    @GetMapping("/apps/{appId}/summary")
+    @PreAuthorize("hasRole('PUBLISHER') or hasRole('ADMIN')")
+    public ResponseEntity<AppAnalyticsSummaryDto> getSummary(
+        @PathVariable String appId,
+
+        @RequestParam(required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        LocalDate from,
+
+        @RequestParam(required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        LocalDate to,
+
+        @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        LocalDate resolvedFrom = from != null ? from : LocalDate.now().minusDays(30);
+        LocalDate resolvedTo   = to   != null ? to   : LocalDate.now();
+
+        validateDateRange(resolvedFrom, resolvedTo);
+
+        return ResponseEntity.ok(queryService.getSummary(appId, resolvedFrom, resolvedTo, principal));
+    }
+
+    /**
+     * 미니앱 이벤트 목록 페이징 조회.
+     *
+     * @param appId     미니앱 식별자
+     * @param eventType 필터 (선택). lifecycle | screen | performance | error | custom | conversion
+     * @param from      조회 시작일 (기본값: 오늘 기준 7일 전)
+     * @param to        조회 종료일 (기본값: 오늘)
+     * @param pageable  page, size(기본 20, 최대 100), sort
+     */
+    @GetMapping("/apps/{appId}/events")
+    @PreAuthorize("hasRole('PUBLISHER') or hasRole('ADMIN')")
+    public ResponseEntity<Page<AnalyticsEventPageDto>> getEvents(
+        @PathVariable String appId,
+
+        @RequestParam(required = false) String eventType,
+
+        @RequestParam(required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        LocalDate from,
+
+        @RequestParam(required = false)
+        @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+        LocalDate to,
+
+        @PageableDefault(size = 20, sort = "clientTimestamp", direction = Sort.Direction.DESC)
+        Pageable pageable,
+
+        @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        LocalDate resolvedFrom = from != null ? from : LocalDate.now().minusDays(7);
+        LocalDate resolvedTo   = to   != null ? to   : LocalDate.now();
+
+        validateDateRange(resolvedFrom, resolvedTo);
+        validatePageSize(pageable);
+
+        return ResponseEntity.ok(
+            queryService.getEvents(appId, eventType, resolvedFrom, resolvedTo, pageable, principal)
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Private — Validation Helpers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private void validateDateRange(LocalDate from, LocalDate to) {
+        if (from.isAfter(to)) {
+            throw new com.union.union.global.common.exception.BadRequestException(
+                "from date must be before or equal to to date"
+            );
+        }
+        if (java.time.temporal.ChronoUnit.DAYS.between(from, to) > 365) {
+            throw new com.union.union.global.common.exception.BadRequestException(
+                "Date range cannot exceed 365 days"
+            );
+        }
+    }
+
+    private void validatePageSize(Pageable pageable) {
+        if (pageable.getPageSize() > 100) {
+            throw new com.union.union.global.common.exception.BadRequestException(
+                "Maximum page size is 100"
+            );
+        }
+    }
+}

--- a/src/main/java/com/union/union/domain/analytics/dto/request/EventBatchRequestDto.java
+++ b/src/main/java/com/union/union/domain/analytics/dto/request/EventBatchRequestDto.java
@@ -1,0 +1,21 @@
+package com.union.union.domain.analytics.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+/**
+ * Analytics 이벤트 배치 수신 요청 DTO.
+ *
+ * <p>네이티브 앱은 최대 100개 이벤트를 하나의 배치로 묶어 전송한다.
+ * 배치 내 모든 이벤트는 동일한 앱({@code X-Union-AppId} 헤더)에 속해야 한다.
+ */
+public record EventBatchRequestDto(
+
+    @NotEmpty(message = "events must not be empty")
+    @Size(max = 100, message = "Maximum 100 events per batch")
+    List<@Valid RawEventDto> events
+
+) {}

--- a/src/main/java/com/union/union/domain/analytics/dto/request/RawEventDto.java
+++ b/src/main/java/com/union/union/domain/analytics/dto/request/RawEventDto.java
@@ -1,0 +1,95 @@
+package com.union.union.domain.analytics.dto.request;
+
+import jakarta.validation.constraints.*;
+
+import java.util.Map;
+
+/**
+ * Native → Server 로 전달되는 개별 트래킹 이벤트 DTO.
+ *
+ * <p>네이티브 앱이 이미 Enrichment(userId 해시, deviceInfo 등)를 완료한 상태로 전달한다.
+ * 서버는 {@code hashedUserId} 를 JWT 기반으로 재검증하여 위변조를 차단한다.
+ */
+public record RawEventDto(
+
+    // ── 이벤트 식별 ──────────────────────────────────────────
+
+    /** lifecycle | screen | performance | error | custom | conversion */
+    @NotBlank
+    @Size(max = 20)
+    String eventType,
+
+    /** /^[a-z][a-z0-9_]{0,99}$/ 형식 강제 (SDK에서 1차 검증 완료) */
+    @NotBlank
+    @Size(max = 100)
+    @Pattern(regexp = "^[a-z][a-z0-9_]{0,99}$",
+             message = "eventName must match /^[a-z][a-z0-9_]{0,99}$/")
+    String eventName,
+
+    // ── 타이밍 ───────────────────────────────────────────────
+
+    /** 클라이언트(네이티브 앱) 이벤트 발생 시각 (epoch ms) */
+    @NotNull
+    @Min(value = 0, message = "clientTimestamp must be a positive epoch ms")
+    Long clientTimestamp,
+
+    // ── 세션 ─────────────────────────────────────────────────
+
+    @NotBlank
+    @Size(max = 36)
+    String sessionId,
+
+    @NotBlank
+    @Size(max = 36)
+    String superappSessionId,
+
+    // ── 사용자 (프라이버시 보존) ──────────────────────────────
+
+    /** SHA-256(userId:appId). 미로그인 시 null 허용. */
+    @Size(max = 64)
+    String hashedUserId,
+
+    // ── 앱 컨텍스트 ──────────────────────────────────────────
+
+    /** union.config.json 의 appId (reverse-domain) */
+    @NotBlank
+    @Size(max = 100)
+    String appId,
+
+    @NotBlank
+    @Size(max = 30)
+    String appVersion,
+
+    @NotBlank
+    @Size(max = 20)
+    String sdkVersion,
+
+    // ── 플랫폼 ───────────────────────────────────────────────
+
+    /** ios | android */
+    @NotBlank
+    @Size(max = 10)
+    String platform,
+
+    @NotBlank
+    @Size(max = 30)
+    String osVersion,
+
+    @NotBlank
+    @Size(max = 50)
+    String deviceModel,
+
+    // ── 순서 ─────────────────────────────────────────────────
+
+    @Min(0)
+    int sequenceNumber,
+
+    // ── 페이로드 ─────────────────────────────────────────────
+
+    /** 이벤트 파라미터. string | number | boolean 값만 허용 (SDK에서 1차 검증). */
+    Map<String, Object> params,
+
+    /** setUserProperty() 로 설정된 사용자 속성 스냅샷. */
+    Map<String, Object> userProperties
+
+) {}

--- a/src/main/java/com/union/union/domain/analytics/dto/response/AnalyticsEventPageDto.java
+++ b/src/main/java/com/union/union/domain/analytics/dto/response/AnalyticsEventPageDto.java
@@ -1,0 +1,44 @@
+package com.union.union.domain.analytics.dto.response;
+
+import com.union.union.domain.analytics.entity.AnalyticsEvent;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * 이벤트 목록 조회용 경량 응답 DTO.
+ * params/userProperties 는 원본 JSON 문자열 그대로 반환.
+ */
+public record AnalyticsEventPageDto(
+    UUID id,
+    String eventType,
+    String eventName,
+    String sessionId,
+    String hashedUserId,
+    String platform,
+    String osVersion,
+    String deviceModel,
+    int sequenceNumber,
+    Instant clientTimestamp,
+    Instant serverTimestamp,
+    String params,
+    String userProperties
+) {
+    public static AnalyticsEventPageDto from(AnalyticsEvent e) {
+        return new AnalyticsEventPageDto(
+            e.getId(),
+            e.getEventType(),
+            e.getEventName(),
+            e.getSessionId(),
+            e.getHashedUserId(),
+            e.getPlatform(),
+            e.getOsVersion(),
+            e.getDeviceModel(),
+            e.getSequenceNumber(),
+            e.getClientTimestamp(),
+            e.getServerTimestamp(),
+            e.getParams(),
+            e.getUserProperties()
+        );
+    }
+}

--- a/src/main/java/com/union/union/domain/analytics/dto/response/AppAnalyticsSummaryDto.java
+++ b/src/main/java/com/union/union/domain/analytics/dto/response/AppAnalyticsSummaryDto.java
@@ -1,0 +1,61 @@
+package com.union.union.domain.analytics.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 미니앱 애널리틱스 요약 응답 DTO.
+ *
+ * <p>퍼블리셔 대시보드의 Analytics 탭에서 소비하는 집계 데이터.
+ *
+ * <ul>
+ *   <li>{@code overview}  — 기간 내 총 이벤트, 고유 세션, 고유 사용자</li>
+ *   <li>{@code eventsByType} — 이벤트 타입별 카운트 맵</li>
+ *   <li>{@code content}  — 상위 화면, 상위 커스텀 이벤트</li>
+ *   <li>{@code errors}   — 에러 합계, 에러율, 상위 에러</li>
+ *   <li>{@code conversions} — 전환 합계, 상위 전환 타입</li>
+ *   <li>{@code performance} — FCP, LCP, page_load, bridge_latency 통계</li>
+ *   <li>{@code dailyTrend}  — 날짜별 이벤트 추이</li>
+ * </ul>
+ */
+public record AppAnalyticsSummaryDto(
+    String appId,
+    LocalDate from,
+    LocalDate to,
+    OverviewDto overview,
+    Map<String, Long> eventsByType,
+    ContentDto content,
+    ErrorsDto errors,
+    ConversionsDto conversions,
+    Map<String, PerformanceStatDto> performance,
+    List<DailyEventCountDto> dailyTrend
+) {
+
+    /** 기간 내 전체 규모 지표 */
+    public record OverviewDto(
+        long totalEvents,
+        long uniqueSessions,
+        long uniqueUsers
+    ) {}
+
+    /** 화면/커스텀 이벤트 상위 목록 */
+    public record ContentDto(
+        List<EventCountDto> topScreenViews,
+        List<EventCountDto> topCustomEvents
+    ) {}
+
+    /** 에러 집계 */
+    public record ErrorsDto(
+        long total,
+        /** errors / totalEvents (0.0 ~ 1.0) */
+        double errorRate,
+        List<EventCountDto> top
+    ) {}
+
+    /** 전환 집계 */
+    public record ConversionsDto(
+        long total,
+        List<EventCountDto> top
+    ) {}
+}

--- a/src/main/java/com/union/union/domain/analytics/dto/response/BatchIngestResponseDto.java
+++ b/src/main/java/com/union/union/domain/analytics/dto/response/BatchIngestResponseDto.java
@@ -1,0 +1,25 @@
+package com.union.union.domain.analytics.dto.response;
+
+import java.util.List;
+
+/**
+ * Analytics 배치 수신 응답 DTO.
+ *
+ * <p>HTTP 200: 모든 이벤트 처리 성공<br>
+ * HTTP 207 Multi-Status: 일부 이벤트 처리 실패 ({@code rejected > 0})
+ */
+public record BatchIngestResponseDto(
+    int accepted,
+    int rejected,
+    List<IngestErrorDto> errors
+) {
+
+    public static BatchIngestResponseDto of(int accepted, List<IngestErrorDto> errors) {
+        return new BatchIngestResponseDto(accepted, errors.size(), errors);
+    }
+
+    /** 멱등성 키 중복 감지 시 반환 (이전 처리 결과 재사용). */
+    public static BatchIngestResponseDto alreadyProcessed() {
+        return new BatchIngestResponseDto(0, 0, List.of());
+    }
+}

--- a/src/main/java/com/union/union/domain/analytics/dto/response/DailyEventCountDto.java
+++ b/src/main/java/com/union/union/domain/analytics/dto/response/DailyEventCountDto.java
@@ -1,0 +1,15 @@
+package com.union.union.domain.analytics.dto.response;
+
+import com.union.union.domain.analytics.repository.projection.DailyCount;
+
+import java.time.LocalDate;
+
+/** 날짜별 이벤트 카운트. 대시보드 추이 차트용. */
+public record DailyEventCountDto(
+    LocalDate date,
+    long count
+) {
+    public static DailyEventCountDto from(DailyCount projection) {
+        return new DailyEventCountDto(projection.getEventDate(), projection.getCount());
+    }
+}

--- a/src/main/java/com/union/union/domain/analytics/dto/response/EventCountDto.java
+++ b/src/main/java/com/union/union/domain/analytics/dto/response/EventCountDto.java
@@ -1,0 +1,16 @@
+package com.union.union.domain.analytics.dto.response;
+
+import com.union.union.domain.analytics.repository.projection.EventNameCount;
+
+/**
+ * 이름-카운트 쌍 범용 DTO.
+ * 상위 화면, 상위 커스텀 이벤트, 상위 에러, 상위 전환 등에 공통 사용.
+ */
+public record EventCountDto(
+    String name,
+    long count
+) {
+    public static EventCountDto from(EventNameCount projection) {
+        return new EventCountDto(projection.getName(), projection.getCount());
+    }
+}

--- a/src/main/java/com/union/union/domain/analytics/dto/response/IngestErrorDto.java
+++ b/src/main/java/com/union/union/domain/analytics/dto/response/IngestErrorDto.java
@@ -1,0 +1,14 @@
+package com.union.union.domain.analytics.dto.response;
+
+/**
+ * 배치 내 개별 이벤트 처리 실패 정보.
+ *
+ * @param index   배치 배열 내 이벤트 인덱스 (0-based)
+ * @param code    에러 코드 (e.g. INVALID_EVENT_TYPE, TIMESTAMP_OUT_OF_RANGE)
+ * @param message 에러 상세 메시지
+ */
+public record IngestErrorDto(
+    int index,
+    String code,
+    String message
+) {}

--- a/src/main/java/com/union/union/domain/analytics/dto/response/PerformanceStatDto.java
+++ b/src/main/java/com/union/union/domain/analytics/dto/response/PerformanceStatDto.java
@@ -1,0 +1,23 @@
+package com.union.union.domain.analytics.dto.response;
+
+import com.union.union.domain.analytics.repository.projection.PerformanceMetricStat;
+
+/**
+ * 단일 성능 지표 통계.
+ * p50(중간값), p95(95th percentile), 평균, 샘플 수 포함.
+ */
+public record PerformanceStatDto(
+    double p50,
+    double p95,
+    double avg,
+    long sampleCount
+) {
+    public static PerformanceStatDto from(PerformanceMetricStat stat) {
+        return new PerformanceStatDto(
+            stat.getP50()         != null ? Math.round(stat.getP50()         * 10) / 10.0 : 0.0,
+            stat.getP95()         != null ? Math.round(stat.getP95()         * 10) / 10.0 : 0.0,
+            stat.getAvgValue()    != null ? Math.round(stat.getAvgValue()    * 10) / 10.0 : 0.0,
+            stat.getSampleCount() != null ? stat.getSampleCount() : 0L
+        );
+    }
+}

--- a/src/main/java/com/union/union/domain/analytics/entity/AnalyticsEvent.java
+++ b/src/main/java/com/union/union/domain/analytics/entity/AnalyticsEvent.java
@@ -1,0 +1,145 @@
+package com.union.union.domain.analytics.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * 미니앱에서 수집된 트래킹 이벤트 원본 레코드.
+ *
+ * <p>JS SDK → Native Bridge → POST /api/v1/analytics/events 경로로 유입된 이벤트를
+ * 네이티브에서 보강(Enrichment)한 최종 페이로드를 그대로 저장한다.
+ *
+ * <p>params / userProperties 는 JSON 문자열로 저장되며,
+ * PostgreSQL 의 {@code ::jsonb} 캐스팅을 통해 네이티브 쿼리에서 JSON 필드 추출이 가능하다.
+ */
+@Entity
+@Table(
+    name = "analytics_events",
+    indexes = {
+        @Index(name = "idx_ae_app_id",          columnList = "app_id"),
+        @Index(name = "idx_ae_app_id_ts",        columnList = "app_id, client_timestamp"),
+        @Index(name = "idx_ae_session_id",       columnList = "session_id"),
+        @Index(name = "idx_ae_event_type_name",  columnList = "event_type, event_name"),
+        @Index(name = "idx_ae_hashed_user_id",   columnList = "hashed_user_id"),
+        @Index(name = "idx_ae_client_timestamp", columnList = "client_timestamp"),
+    }
+)
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class AnalyticsEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "uuid", updatable = false, nullable = false)
+    private UUID id;
+
+    // ──────────────────────────────────────────────────────
+    // 이벤트 식별
+    // ──────────────────────────────────────────────────────
+
+    /**
+     * 이벤트 분류. lifecycle | screen | performance | error | custom | conversion
+     */
+    @Column(name = "event_type", nullable = false, length = 20)
+    private String eventType;
+
+    /**
+     * 이벤트 이름. SDK 레벨에서 /^[a-z][a-z0-9_]{0,99}$/ 형식이 강제됨.
+     */
+    @Column(name = "event_name", nullable = false, length = 100)
+    private String eventName;
+
+    // ──────────────────────────────────────────────────────
+    // 앱 컨텍스트
+    // ──────────────────────────────────────────────────────
+
+    /** 미니앱 식별자 (reverse-domain, e.g. "com.union.soccer") */
+    @Column(name = "app_id", nullable = false, length = 100)
+    private String appId;
+
+    @Column(name = "app_version", nullable = false, length = 30)
+    private String appVersion;
+
+    @Column(name = "sdk_version", nullable = false, length = 20)
+    private String sdkVersion;
+
+    // ──────────────────────────────────────────────────────
+    // 세션
+    // ──────────────────────────────────────────────────────
+
+    /** 미니앱 실행 단위 세션 UUID */
+    @Column(name = "session_id", nullable = false, length = 36)
+    private String sessionId;
+
+    /** 슈퍼앱 전체 세션 UUID (크로스 미니앱 세션 분석용) */
+    @Column(name = "superapp_session_id", nullable = false, length = 36)
+    private String superappSessionId;
+
+    // ──────────────────────────────────────────────────────
+    // 사용자 (프라이버시 보존)
+    // ──────────────────────────────────────────────────────
+
+    /**
+     * SHA-256(userId:appId). 미로그인/익명 세션 시 null.
+     * 원본 userId 는 서버에 저장하지 않는다.
+     */
+    @Column(name = "hashed_user_id", length = 64)
+    private String hashedUserId;
+
+    // ──────────────────────────────────────────────────────
+    // 플랫폼
+    // ──────────────────────────────────────────────────────
+
+    @Column(nullable = false, length = 10)
+    private String platform;
+
+    @Column(name = "os_version", nullable = false, length = 30)
+    private String osVersion;
+
+    @Column(name = "device_model", nullable = false, length = 50)
+    private String deviceModel;
+
+    // ──────────────────────────────────────────────────────
+    // 순서 및 타이밍
+    // ──────────────────────────────────────────────────────
+
+    /** 세션 내 이벤트 순서 (0부터 증가). 네이티브가 설정. 이벤트 유실 감지용. */
+    @Column(name = "sequence_number", nullable = false)
+    private int sequenceNumber;
+
+    /** 클라이언트(네이티브 앱) 측 이벤트 발생 시각 */
+    @Column(name = "client_timestamp", nullable = false)
+    private Instant clientTimestamp;
+
+    /** 서버 수신 시각 (신뢰 기준 타임스탬프). 자동 설정. */
+    @CreatedDate
+    @Column(name = "server_timestamp", nullable = false, updatable = false)
+    private Instant serverTimestamp;
+
+    // ──────────────────────────────────────────────────────
+    // 페이로드 (JSON)
+    // ──────────────────────────────────────────────────────
+
+    /**
+     * 이벤트 파라미터 (JSON 문자열).
+     * PII 는 SDK 및 네이티브에서 2중 마스킹됨.
+     * Native SQL 에서 {@code params::jsonb->>'key'} 로 접근 가능.
+     */
+    @Column(name = "params", columnDefinition = "TEXT")
+    private String params;
+
+    /**
+     * 이벤트 발생 시점의 사용자 속성 스냅샷 (JSON 문자열).
+     * Native SQL 에서 {@code user_properties::jsonb->>'key'} 로 접근 가능.
+     */
+    @Column(name = "user_properties", columnDefinition = "TEXT")
+    private String userProperties;
+}

--- a/src/main/java/com/union/union/domain/analytics/repository/AnalyticsEventRepository.java
+++ b/src/main/java/com/union/union/domain/analytics/repository/AnalyticsEventRepository.java
@@ -1,0 +1,247 @@
+package com.union.union.domain.analytics.repository;
+
+import com.union.union.domain.analytics.entity.AnalyticsEvent;
+import com.union.union.domain.analytics.repository.projection.DailyCount;
+import com.union.union.domain.analytics.repository.projection.EventNameCount;
+import com.union.union.domain.analytics.repository.projection.PerformanceMetricStat;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface AnalyticsEventRepository extends JpaRepository<AnalyticsEvent, UUID> {
+
+    // ──────────────────────────────────────────────────────────────
+    // 기본 카운트 (JPQL — 인덱스 활용)
+    // ──────────────────────────────────────────────────────────────
+
+    long countByAppIdAndClientTimestampBetween(String appId, Instant from, Instant to);
+
+    @Query("SELECT COUNT(DISTINCT e.sessionId) FROM AnalyticsEvent e " +
+           "WHERE e.appId = :appId AND e.clientTimestamp BETWEEN :from AND :to")
+    long countDistinctSessions(
+        @Param("appId") String appId,
+        @Param("from") Instant from,
+        @Param("to") Instant to
+    );
+
+    @Query("SELECT COUNT(DISTINCT e.hashedUserId) FROM AnalyticsEvent e " +
+           "WHERE e.appId = :appId AND e.clientTimestamp BETWEEN :from AND :to " +
+           "AND e.hashedUserId IS NOT NULL")
+    long countDistinctUsers(
+        @Param("appId") String appId,
+        @Param("from") Instant from,
+        @Param("to") Instant to
+    );
+
+    // ──────────────────────────────────────────────────────────────
+    // 이벤트 타입별 카운트
+    // ──────────────────────────────────────────────────────────────
+
+    /**
+     * 이벤트 타입별 카운트 집계.
+     * alias: {@code name} = eventType, {@code count} = COUNT(*)
+     */
+    @Query(nativeQuery = true, value = """
+        SELECT event_type  AS name,
+               COUNT(*)    AS count
+        FROM   analytics_events
+        WHERE  app_id           = :appId
+          AND  client_timestamp BETWEEN :from AND :to
+        GROUP  BY event_type
+        ORDER  BY count DESC
+        """)
+    List<EventNameCount> countByEventType(
+        @Param("appId") String appId,
+        @Param("from") Instant from,
+        @Param("to") Instant to
+    );
+
+    // ──────────────────────────────────────────────────────────────
+    // 콘텐츠 분석
+    // ──────────────────────────────────────────────────────────────
+
+    /**
+     * 상위 화면 뷰 목록.
+     * {@code params} 컬럼을 jsonb 로 캐스팅하여 pageName 추출.
+     */
+    @Query(nativeQuery = true, value = """
+        SELECT params::jsonb->>'pageName' AS name,
+               COUNT(*)                  AS count
+        FROM   analytics_events
+        WHERE  app_id           = :appId
+          AND  event_type       = 'screen'
+          AND  event_name       = 'screen_view'
+          AND  client_timestamp BETWEEN :from AND :to
+          AND  params           IS NOT NULL
+        GROUP  BY params::jsonb->>'pageName'
+        ORDER  BY count DESC
+        LIMIT  :limit
+        """)
+    List<EventNameCount> findTopScreenViews(
+        @Param("appId") String appId,
+        @Param("from") Instant from,
+        @Param("to") Instant to,
+        @Param("limit") int limit
+    );
+
+    /**
+     * 상위 커스텀 이벤트 목록.
+     */
+    @Query(nativeQuery = true, value = """
+        SELECT event_name AS name,
+               COUNT(*)   AS count
+        FROM   analytics_events
+        WHERE  app_id           = :appId
+          AND  event_type       = 'custom'
+          AND  client_timestamp BETWEEN :from AND :to
+        GROUP  BY event_name
+        ORDER  BY count DESC
+        LIMIT  :limit
+        """)
+    List<EventNameCount> findTopCustomEvents(
+        @Param("appId") String appId,
+        @Param("from") Instant from,
+        @Param("to") Instant to,
+        @Param("limit") int limit
+    );
+
+    // ──────────────────────────────────────────────────────────────
+    // 에러 분석
+    // ──────────────────────────────────────────────────────────────
+
+    long countByAppIdAndEventTypeAndClientTimestampBetween(
+        String appId, String eventType, Instant from, Instant to
+    );
+
+    /**
+     * 상위 에러 이벤트 목록.
+     */
+    @Query(nativeQuery = true, value = """
+        SELECT event_name AS name,
+               COUNT(*)   AS count
+        FROM   analytics_events
+        WHERE  app_id           = :appId
+          AND  event_type       = 'error'
+          AND  client_timestamp BETWEEN :from AND :to
+        GROUP  BY event_name
+        ORDER  BY count DESC
+        LIMIT  :limit
+        """)
+    List<EventNameCount> findTopErrors(
+        @Param("appId") String appId,
+        @Param("from") Instant from,
+        @Param("to") Instant to,
+        @Param("limit") int limit
+    );
+
+    // ──────────────────────────────────────────────────────────────
+    // 전환 분석
+    // ──────────────────────────────────────────────────────────────
+
+    /**
+     * 상위 전환 타입 목록.
+     * conversionType 은 params::jsonb->>'conversionType' 에서 추출.
+     */
+    @Query(nativeQuery = true, value = """
+        SELECT params::jsonb->>'conversionType' AS name,
+               COUNT(*)                         AS count
+        FROM   analytics_events
+        WHERE  app_id           = :appId
+          AND  event_type       = 'conversion'
+          AND  client_timestamp BETWEEN :from AND :to
+          AND  params           IS NOT NULL
+        GROUP  BY params::jsonb->>'conversionType'
+        ORDER  BY count DESC
+        LIMIT  :limit
+        """)
+    List<EventNameCount> findTopConversions(
+        @Param("appId") String appId,
+        @Param("from") Instant from,
+        @Param("to") Instant to,
+        @Param("limit") int limit
+    );
+
+    // ──────────────────────────────────────────────────────────────
+    // 성능 지표 (percentile_cont)
+    // ──────────────────────────────────────────────────────────────
+
+    /**
+     * 성능 지표별 p50, p95, 평균, 샘플 수 집계.
+     *
+     * <p>대상 지표: first_contentful_paint, largest_contentful_paint,
+     * page_load, dom_content_loaded, bridge_latency
+     *
+     * <p>alias: metricName, p50, p95, avgValue, sampleCount
+     */
+    @Query(nativeQuery = true, value = """
+        SELECT
+            params::jsonb->>'metricName'                                                                   AS "metricName",
+            PERCENTILE_CONT(0.5)  WITHIN GROUP (ORDER BY (params::jsonb->>'value')::float8)                AS p50,
+            PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY (params::jsonb->>'value')::float8)                AS p95,
+            AVG((params::jsonb->>'value')::float8)                                                         AS "avgValue",
+            COUNT(*)                                                                                        AS "sampleCount"
+        FROM  analytics_events
+        WHERE app_id           = :appId
+          AND event_type       = 'performance'
+          AND event_name       = 'performance_metric'
+          AND client_timestamp BETWEEN :from AND :to
+          AND params           IS NOT NULL
+          AND params::jsonb->>'metricName' IN (
+                'first_contentful_paint',
+                'largest_contentful_paint',
+                'page_load',
+                'dom_content_loaded',
+                'bridge_latency'
+              )
+        GROUP BY params::jsonb->>'metricName'
+        """)
+    List<PerformanceMetricStat> findPerformanceStats(
+        @Param("appId") String appId,
+        @Param("from") Instant from,
+        @Param("to") Instant to
+    );
+
+    // ──────────────────────────────────────────────────────────────
+    // 일별 추이
+    // ──────────────────────────────────────────────────────────────
+
+    /**
+     * 날짜별 이벤트 카운트 (KST 기준).
+     * alias: eventDate (LocalDate), count (Long)
+     */
+    @Query(nativeQuery = true, value = """
+        SELECT
+            DATE(client_timestamp AT TIME ZONE 'Asia/Seoul')  AS "eventDate",
+            COUNT(*)                                          AS count
+        FROM  analytics_events
+        WHERE app_id           = :appId
+          AND client_timestamp BETWEEN :from AND :to
+        GROUP BY DATE(client_timestamp AT TIME ZONE 'Asia/Seoul')
+        ORDER BY "eventDate"
+        """)
+    List<DailyCount> findDailyTrend(
+        @Param("appId") String appId,
+        @Param("from") Instant from,
+        @Param("to") Instant to
+    );
+
+    // ──────────────────────────────────────────────────────────────
+    // 이벤트 목록 (페이징)
+    // ──────────────────────────────────────────────────────────────
+
+    Page<AnalyticsEvent> findByAppIdAndClientTimestampBetween(
+        String appId, Instant from, Instant to, Pageable pageable
+    );
+
+    Page<AnalyticsEvent> findByAppIdAndEventTypeAndClientTimestampBetween(
+        String appId, String eventType, Instant from, Instant to, Pageable pageable
+    );
+}

--- a/src/main/java/com/union/union/domain/analytics/repository/projection/DailyCount.java
+++ b/src/main/java/com/union/union/domain/analytics/repository/projection/DailyCount.java
@@ -1,0 +1,13 @@
+package com.union.union.domain.analytics.repository.projection;
+
+import java.time.LocalDate;
+
+/**
+ * 일별 이벤트 카운트 프로젝션.
+ *
+ * <p>SQL 컬럼 alias: {@code eventDate}, {@code count}
+ */
+public interface DailyCount {
+    LocalDate getEventDate();
+    Long getCount();
+}

--- a/src/main/java/com/union/union/domain/analytics/repository/projection/EventNameCount.java
+++ b/src/main/java/com/union/union/domain/analytics/repository/projection/EventNameCount.java
@@ -1,0 +1,12 @@
+package com.union.union.domain.analytics.repository.projection;
+
+/**
+ * 이벤트 이름별 카운트 프로젝션.
+ * Native Query 결과를 Spring Data JPA 인터페이스 프로젝션으로 매핑.
+ *
+ * <p>SQL 컬럼 alias: {@code name}, {@code count}
+ */
+public interface EventNameCount {
+    String getName();
+    Long getCount();
+}

--- a/src/main/java/com/union/union/domain/analytics/repository/projection/PerformanceMetricStat.java
+++ b/src/main/java/com/union/union/domain/analytics/repository/projection/PerformanceMetricStat.java
@@ -1,0 +1,16 @@
+package com.union.union.domain.analytics.repository.projection;
+
+/**
+ * 성능 지표 통계 프로젝션.
+ * {@code percentile_cont} 를 사용한 Native Query 결과 매핑.
+ *
+ * <p>SQL 컬럼 alias: {@code metricName}, {@code p50}, {@code p95},
+ * {@code avgValue}, {@code sampleCount}
+ */
+public interface PerformanceMetricStat {
+    String getMetricName();
+    Double getP50();
+    Double getP95();
+    Double getAvgValue();
+    Long getSampleCount();
+}

--- a/src/main/java/com/union/union/domain/analytics/service/AnalyticsHasher.java
+++ b/src/main/java/com/union/union/domain/analytics/service/AnalyticsHasher.java
@@ -1,0 +1,53 @@
+package com.union.union.domain.analytics.service;
+
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.UUID;
+
+/**
+ * Analytics 전용 해시 유틸리티.
+ *
+ * <p>iOS 네이티브가 {@code SHA-256(userId + ":" + appId)} 로 생성한 hashedUserId 를
+ * 서버에서 재계산하여 검증한다.
+ *
+ * <p>원본 userId 는 절대 DB에 저장되지 않는다.
+ */
+@Component
+public class AnalyticsHasher {
+
+    /**
+     * SHA-256(userId.toString() + ":" + appId) 를 64자 hex 문자열로 반환.
+     *
+     * @param userId 현재 인증된 사용자 UUID (JWT sub 클레임)
+     * @param appId  미니앱 식별자 (e.g. "com.union.soccer")
+     * @return 64자 소문자 hex 해시
+     */
+    public String hash(UUID userId, String appId) {
+        String input = userId.toString() + ":" + appId;
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hashBytes = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(64);
+            for (byte b : hashBytes) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 은 Java SE 필수 알고리즘이므로 절대 발생하지 않음
+            throw new IllegalStateException("SHA-256 algorithm not available", e);
+        }
+    }
+
+    /**
+     * 네이티브가 전달한 hashedUserId 가 서버 재계산 값과 일치하는지 검증.
+     *
+     * @return true = 유효 / false = 위변조 의심
+     */
+    public boolean verify(UUID userId, String appId, String providedHash) {
+        if (providedHash == null || providedHash.isBlank()) return false;
+        return hash(userId, appId).equals(providedHash);
+    }
+}

--- a/src/main/java/com/union/union/domain/analytics/service/AnalyticsIngestService.java
+++ b/src/main/java/com/union/union/domain/analytics/service/AnalyticsIngestService.java
@@ -1,0 +1,291 @@
+package com.union.union.domain.analytics.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.union.union.domain.analytics.dto.request.EventBatchRequestDto;
+import com.union.union.domain.analytics.dto.request.RawEventDto;
+import com.union.union.domain.analytics.dto.response.BatchIngestResponseDto;
+import com.union.union.domain.analytics.dto.response.IngestErrorDto;
+import com.union.union.domain.analytics.entity.AnalyticsEvent;
+import com.union.union.domain.analytics.repository.AnalyticsEventRepository;
+import com.union.union.domain.miniapp.entity.MiniAppStatus;
+import com.union.union.domain.miniapp.repository.MiniAppRepository;
+import com.union.union.global.common.exception.EntityNotFoundException;
+import com.union.union.global.infra.redis.RedisService;
+import com.union.union.global.security.jwt.JwtUserPrincipal;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Analytics 이벤트 배치 수신 서비스.
+ *
+ * <h3>처리 흐름</h3>
+ * <ol>
+ *   <li>멱등성 키 중복 체크 (Redis, TTL 24h)</li>
+ *   <li>appId 검증 — APPROVED 상태 미니앱만 허용 (Redis 캐시 5분)</li>
+ *   <li>배치 내 헤더 appId 와 이벤트 appId 불일치 검사</li>
+ *   <li>이벤트별 유효성 검사 (타임스탬프 범위, eventType, platform 등)</li>
+ *   <li>hashedUserId JWT 재검증 — 위변조 이벤트 거절</li>
+ *   <li>유효 이벤트 벌크 저장 (saveAll)</li>
+ *   <li>Redis 실시간 카운터 업데이트 (이벤트 타입별 INCR)</li>
+ *   <li>멱등성 키 마킹</li>
+ * </ol>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AnalyticsIngestService {
+
+    private static final Set<String> VALID_EVENT_TYPES =
+        Set.of("lifecycle", "screen", "performance", "error", "custom", "conversion");
+
+    private static final Set<String> VALID_PLATFORMS = Set.of("ios", "android");
+
+    /** 클라이언트 타임스탬프 허용 범위: 과거 24시간 ~ 미래 5분 */
+    private static final Duration MAX_PAST_WINDOW   = Duration.ofHours(24);
+    private static final Duration MAX_FUTURE_WINDOW = Duration.ofMinutes(5);
+
+    /** 멱등성 키 TTL */
+    private static final Duration IDEMPOTENCY_TTL = Duration.ofDays(1);
+
+    /** Redis 실시간 카운터 TTL (당일 기준, 다음날 자정 이후 자동 만료) */
+    private static final Duration COUNTER_TTL = Duration.ofDays(2);
+
+    private final AnalyticsEventRepository eventRepository;
+    private final MiniAppRepository        miniAppRepository;
+    private final AnalyticsHasher          hasher;
+    private final RedisService             redisService;
+    private final ObjectMapper             objectMapper;
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Public API
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * 이벤트 배치 수신 및 저장.
+     *
+     * @param requestId  X-Request-ID 헤더 (멱등성 키)
+     * @param headerAppId X-Union-AppId 헤더 (배치 단위 앱 식별)
+     * @param batch      요청 본문
+     * @param principal  현재 인증된 사용자 (JWT)
+     */
+    public BatchIngestResponseDto ingest(
+        String requestId,
+        String headerAppId,
+        EventBatchRequestDto batch,
+        JwtUserPrincipal principal
+    ) {
+        // 1. 멱등성 중복 체크
+        String idempotencyKey = buildIdempotencyKey(requestId);
+        if (redisService.hasKey(idempotencyKey)) {
+            log.debug("[Analytics] Duplicate batch ignored: requestId={}", requestId);
+            return BatchIngestResponseDto.alreadyProcessed();
+        }
+
+        // 2. appId → APPROVED MiniApp 검증 (캐시)
+        validateAppId(headerAppId);
+
+        // 3. 이벤트별 검증 및 엔티티 변환
+        List<AnalyticsEvent> toSave = new ArrayList<>();
+        List<IngestErrorDto> errors  = new ArrayList<>();
+        Instant now = Instant.now();
+
+        for (int i = 0; i < batch.events().size(); i++) {
+            RawEventDto raw = batch.events().get(i);
+            try {
+                validateEvent(raw, headerAppId, principal.userId(), now);
+                toSave.add(toEntity(raw));
+            } catch (AnalyticsValidationException e) {
+                log.debug("[Analytics] Event[{}] rejected: {}", i, e.getMessage());
+                errors.add(new IngestErrorDto(i, e.getCode(), e.getMessage()));
+            }
+        }
+
+        // 4. 벌크 저장
+        if (!toSave.isEmpty()) {
+            eventRepository.saveAll(toSave);
+            updateRealtimeCounters(headerAppId, toSave);
+        }
+
+        // 5. 멱등성 키 마킹
+        redisService.setValuesWithTimeout(idempotencyKey, "1", IDEMPOTENCY_TTL);
+
+        int accepted = toSave.size();
+        log.info("[Analytics] Batch processed: appId={}, accepted={}, rejected={}", headerAppId, accepted, errors.size());
+        return BatchIngestResponseDto.of(accepted, errors);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Private — Validation
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * appId 에 해당하는 APPROVED 미니앱 존재 여부 검증.
+     * Redis 에 직접 캐싱 (5분 TTL).
+     *
+     * <p>Spring AOP 프록시 self-invocation 문제를 피하기 위해
+     * {@code @Cacheable} 대신 Redis 직접 캐싱 방식을 사용한다.
+     *
+     * @throws EntityNotFoundException 등록되지 않거나 미승인 앱
+     */
+    private void validateAppId(String appId) {
+        String cacheKey = "analyticsAppId:" + appId;
+
+        // 캐시 히트 → 검증 완료된 appId
+        if (redisService.hasKey(cacheKey)) return;
+
+        boolean exists = miniAppRepository.existsByAppIdAndStatus(appId, MiniAppStatus.APPROVED);
+        if (!exists) {
+            throw new EntityNotFoundException(
+                "Mini-app not found or not approved: appId=" + appId
+            );
+        }
+
+        // 검증 결과 5분간 캐싱
+        redisService.setValuesWithTimeout(cacheKey, "valid", Duration.ofMinutes(5));
+    }
+
+    private void validateEvent(RawEventDto raw, String headerAppId, UUID userId, Instant now) {
+        // appId 불일치
+        if (!headerAppId.equals(raw.appId())) {
+            throw new AnalyticsValidationException(
+                "APP_ID_MISMATCH",
+                "Event appId does not match X-Union-AppId header"
+            );
+        }
+
+        // eventType 화이트리스트
+        if (!VALID_EVENT_TYPES.contains(raw.eventType())) {
+            throw new AnalyticsValidationException(
+                "INVALID_EVENT_TYPE",
+                "Unknown eventType: " + raw.eventType()
+            );
+        }
+
+        // platform 화이트리스트
+        if (!VALID_PLATFORMS.contains(raw.platform())) {
+            throw new AnalyticsValidationException(
+                "INVALID_PLATFORM",
+                "Unknown platform: " + raw.platform()
+            );
+        }
+
+        // 타임스탬프 범위
+        Instant clientTs = Instant.ofEpochMilli(raw.clientTimestamp());
+        if (clientTs.isBefore(now.minus(MAX_PAST_WINDOW))) {
+            throw new AnalyticsValidationException(
+                "TIMESTAMP_TOO_OLD",
+                "clientTimestamp is older than 24 hours"
+            );
+        }
+        if (clientTs.isAfter(now.plus(MAX_FUTURE_WINDOW))) {
+            throw new AnalyticsValidationException(
+                "TIMESTAMP_IN_FUTURE",
+                "clientTimestamp is too far in the future"
+            );
+        }
+
+        // hashedUserId JWT 재검증 (제공된 경우에만)
+        if (raw.hashedUserId() != null && !raw.hashedUserId().isBlank()) {
+            if (!hasher.verify(userId, raw.appId(), raw.hashedUserId())) {
+                throw new AnalyticsValidationException(
+                    "HASHED_USER_ID_MISMATCH",
+                    "hashedUserId does not match JWT identity"
+                );
+            }
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Private — Mapping
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private AnalyticsEvent toEntity(RawEventDto raw) {
+        return AnalyticsEvent.builder()
+            .eventType(raw.eventType())
+            .eventName(raw.eventName())
+            .appId(raw.appId())
+            .appVersion(raw.appVersion())
+            .sdkVersion(raw.sdkVersion())
+            .sessionId(raw.sessionId())
+            .superappSessionId(raw.superappSessionId())
+            .hashedUserId(raw.hashedUserId())
+            .platform(raw.platform())
+            .osVersion(raw.osVersion())
+            .deviceModel(raw.deviceModel())
+            .sequenceNumber(raw.sequenceNumber())
+            .clientTimestamp(Instant.ofEpochMilli(raw.clientTimestamp()))
+            .params(toJson(raw.params()))
+            .userProperties(toJson(raw.userProperties()))
+            .build();
+    }
+
+    private String toJson(Object value) {
+        if (value == null) return null;
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            log.warn("[Analytics] Failed to serialize params to JSON", e);
+            return null;
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Private — Redis Counters
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * 이벤트 타입별 실시간 카운터 업데이트.
+     * 대시보드 "오늘의 통계" 에서 DB 조회 없이 빠르게 읽을 수 있도록.
+     *
+     * <p>key 형식: {@code analytics:daily:{appId}:{YYYY-MM-DD}}
+     * <p>value: Sorted Set (eventType → score)
+     */
+    private void updateRealtimeCounters(String appId, List<AnalyticsEvent> events) {
+        String today = java.time.LocalDate.now().toString(); // YYYY-MM-DD
+        String counterKey = buildDailyCounterKey(appId, today);
+
+        for (AnalyticsEvent event : events) {
+            redisService.incrementScore(counterKey, event.getEventType(), 1.0);
+        }
+        // 카운터 TTL 갱신 (2일)
+        redisService.setExpire(counterKey, COUNTER_TTL);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Private — Key Builders
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private static String buildIdempotencyKey(String requestId) {
+        return "analytics:batch:" + requestId;
+    }
+
+    public static String buildDailyCounterKey(String appId, String date) {
+        return "analytics:daily:" + appId + ":" + date;
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Inner — Validation Exception
+    // ──────────────────────────────────────────────────────────────────────────
+
+    static class AnalyticsValidationException extends RuntimeException {
+        private final String code;
+
+        AnalyticsValidationException(String code, String message) {
+            super(message);
+            this.code = code;
+        }
+
+        String getCode() { return code; }
+    }
+}

--- a/src/main/java/com/union/union/domain/analytics/service/AnalyticsQueryService.java
+++ b/src/main/java/com/union/union/domain/analytics/service/AnalyticsQueryService.java
@@ -1,0 +1,200 @@
+package com.union.union.domain.analytics.service;
+
+import com.union.union.domain.analytics.dto.response.*;
+import com.union.union.domain.analytics.repository.AnalyticsEventRepository;
+import com.union.union.domain.analytics.repository.projection.EventNameCount;
+import com.union.union.domain.analytics.repository.projection.PerformanceMetricStat;
+import com.union.union.domain.miniapp.entity.MiniApp;
+import com.union.union.domain.miniapp.entity.MiniAppStatus;
+import com.union.union.domain.miniapp.repository.MiniAppRepository;
+import com.union.union.domain.workspace.service.WorkspaceAuthorizationService;
+import com.union.union.global.common.exception.EntityNotFoundException;
+import com.union.union.global.security.jwt.JwtUserPrincipal;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Analytics 조회 서비스 (퍼블리셔 대시보드용).
+ *
+ * <h3>캐싱 전략</h3>
+ * <ul>
+ *   <li>{@code analyticsSummary} — 5분 TTL. 집계 쿼리 부하 방지</li>
+ * </ul>
+ *
+ * <h3>인가 (Authorization)</h3>
+ * <ul>
+ *   <li>ROLE_ADMIN: 모든 앱 조회 가능</li>
+ *   <li>ROLE_PUBLISHER: 자신의 워크스페이스 미니앱만 조회 가능</li>
+ * </ul>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AnalyticsQueryService {
+
+    private static final ZoneId KST          = ZoneId.of("Asia/Seoul");
+    private static final int    TOP_LIMIT     = 10;
+
+    private final AnalyticsEventRepository      eventRepository;
+    private final MiniAppRepository             miniAppRepository;
+    private final WorkspaceAuthorizationService workspaceAuthorizationService;
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Public API
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * 미니앱 Analytics 요약 조회.
+     * 캐시 키: {@code analyticsSummary::{appId}_{from}_{to}}
+     *
+     * @throws EntityNotFoundException appId 에 해당하는 앱이 없을 때
+     * @throws com.union.union.global.common.exception.UnauthorizedAccessException
+     *         퍼블리셔가 해당 앱 워크스페이스 멤버가 아닐 때
+     */
+    @Cacheable(
+        value    = "analyticsSummary",
+        key      = "#appId + '_' + #from + '_' + #to",
+        condition = "#principal.role() != 'ROLE_ADMIN'"   // Admin 은 캐시 바이패스 (실시간 필요)
+    )
+    public AppAnalyticsSummaryDto getSummary(
+        String appId,
+        LocalDate from,
+        LocalDate to,
+        JwtUserPrincipal principal
+    ) {
+        authorizeAccess(appId, principal);
+
+        Instant fromInstant = from.atStartOfDay(KST).toInstant();
+        Instant toInstant   = to.plusDays(1).atStartOfDay(KST).toInstant();
+
+        // 1. 기본 지표
+        long totalEvents    = eventRepository.countByAppIdAndClientTimestampBetween(appId, fromInstant, toInstant);
+        long uniqueSessions = eventRepository.countDistinctSessions(appId, fromInstant, toInstant);
+        long uniqueUsers    = eventRepository.countDistinctUsers(appId, fromInstant, toInstant);
+
+        // 2. 이벤트 타입별 카운트
+        Map<String, Long> eventsByType = eventRepository.countByEventType(appId, fromInstant, toInstant)
+            .stream()
+            .collect(Collectors.toMap(
+                EventNameCount::getName,
+                EventNameCount::getCount,
+                (a, b) -> a,
+                LinkedHashMap::new
+            ));
+
+        // 3. 콘텐츠 분석
+        List<EventCountDto> topScreenViews   = toEventCountDtos(eventRepository.findTopScreenViews(appId, fromInstant, toInstant, TOP_LIMIT));
+        List<EventCountDto> topCustomEvents  = toEventCountDtos(eventRepository.findTopCustomEvents(appId, fromInstant, toInstant, TOP_LIMIT));
+
+        // 4. 에러 분석
+        long totalErrors = eventsByType.getOrDefault("error", 0L);
+        double errorRate = totalEvents > 0 ? (double) totalErrors / totalEvents : 0.0;
+        List<EventCountDto> topErrors = toEventCountDtos(eventRepository.findTopErrors(appId, fromInstant, toInstant, TOP_LIMIT));
+
+        // 5. 전환 분석
+        long totalConversions = eventsByType.getOrDefault("conversion", 0L);
+        List<EventCountDto> topConversions = toEventCountDtos(eventRepository.findTopConversions(appId, fromInstant, toInstant, TOP_LIMIT));
+
+        // 6. 성능 지표
+        Map<String, PerformanceStatDto> performance = eventRepository
+            .findPerformanceStats(appId, fromInstant, toInstant)
+            .stream()
+            .collect(Collectors.toMap(
+                PerformanceMetricStat::getMetricName,
+                PerformanceStatDto::from,
+                (a, b) -> a,
+                LinkedHashMap::new
+            ));
+
+        // 7. 일별 추이
+        List<DailyEventCountDto> dailyTrend = eventRepository
+            .findDailyTrend(appId, fromInstant, toInstant)
+            .stream()
+            .map(DailyEventCountDto::from)
+            .toList();
+
+        return new AppAnalyticsSummaryDto(
+            appId, from, to,
+            new AppAnalyticsSummaryDto.OverviewDto(totalEvents, uniqueSessions, uniqueUsers),
+            eventsByType,
+            new AppAnalyticsSummaryDto.ContentDto(topScreenViews, topCustomEvents),
+            new AppAnalyticsSummaryDto.ErrorsDto(totalErrors, Math.round(errorRate * 10000.0) / 10000.0, topErrors),
+            new AppAnalyticsSummaryDto.ConversionsDto(totalConversions, topConversions),
+            performance,
+            dailyTrend
+        );
+    }
+
+    /**
+     * 이벤트 목록 페이징 조회.
+     *
+     * @param eventType null 이면 전체 타입 조회
+     */
+    public Page<AnalyticsEventPageDto> getEvents(
+        String appId,
+        String eventType,
+        LocalDate from,
+        LocalDate to,
+        Pageable pageable,
+        JwtUserPrincipal principal
+    ) {
+        authorizeAccess(appId, principal);
+
+        Instant fromInstant = from.atStartOfDay(KST).toInstant();
+        Instant toInstant   = to.plusDays(1).atStartOfDay(KST).toInstant();
+
+        if (eventType != null && !eventType.isBlank()) {
+            return eventRepository
+                .findByAppIdAndEventTypeAndClientTimestampBetween(appId, eventType, fromInstant, toInstant, pageable)
+                .map(AnalyticsEventPageDto::from);
+        }
+
+        return eventRepository
+            .findByAppIdAndClientTimestampBetween(appId, fromInstant, toInstant, pageable)
+            .map(AnalyticsEventPageDto::from);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Private — Authorization
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /**
+     * PUBLISHER 는 자신의 워크스페이스 앱만 조회 가능.
+     * ADMIN 은 모든 앱 조회 가능.
+     */
+    private void authorizeAccess(String appId, JwtUserPrincipal principal) {
+        if ("ROLE_ADMIN".equals(principal.role())) return;
+
+        MiniApp miniApp = miniAppRepository.findByAppId(appId)
+            .orElseThrow(() -> new EntityNotFoundException("Mini-app not found: " + appId));
+
+        workspaceAuthorizationService.validateMembership(
+            miniApp.getWorkspace().getWorkspaceId(),
+            principal.userId()
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Private — Mapping
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private List<EventCountDto> toEventCountDtos(List<EventNameCount> projections) {
+        return projections.stream()
+            .map(EventCountDto::from)
+            .toList();
+    }
+}

--- a/src/main/java/com/union/union/domain/miniapp/entity/MiniApp.java
+++ b/src/main/java/com/union/union/domain/miniapp/entity/MiniApp.java
@@ -40,6 +40,14 @@ public class MiniApp extends BaseEntity {
     @Column(nullable = false, length = 20)
     private MiniAppStatus status;
 
+    /**
+     * 미니앱 식별자 (reverse-domain, e.g. "com.union.soccer").
+     * union.config.json 의 appId 와 동일. Analytics 이벤트 매핑 키.
+     * 기존 앱은 null 허용, 신규 앱은 non-null.
+     */
+    @Column(name = "app_id", unique = true, length = 100)
+    private String appId;
+
     @Builder
     public MiniApp(String name, String description, String iconUrl, MiniAppCategory category, String tags, Workspace workspace, MiniAppStatus status) {
         this.name = name;
@@ -51,11 +59,15 @@ public class MiniApp extends BaseEntity {
         this.status = status != null ? status : MiniAppStatus.PENDING;
     }
 
+    public void updateAppId(String appId) {
+        this.appId = appId;
+    }
+
     public void approve() {
         this.status = MiniAppStatus.APPROVED;
     }
 
-public void reject() {
+    public void reject() {
         this.status = MiniAppStatus.REJECTED;
     }
 }

--- a/src/main/java/com/union/union/domain/miniapp/repository/MiniAppRepository.java
+++ b/src/main/java/com/union/union/domain/miniapp/repository/MiniAppRepository.java
@@ -70,4 +70,21 @@ public interface MiniAppRepository extends JpaRepository<MiniApp, Long> {
 
     @Query("SELECT m FROM MiniApp m JOIN FETCH m.workspace WHERE m.status = 'APPROVED' ORDER BY FUNCTION('RANDOM')")
     List<MiniApp> findRandomMiniApps(Pageable pageable);
+
+    // ──────────────────────────────────────────────────────────────
+    // Analytics 연동
+    // ──────────────────────────────────────────────────────────────
+
+    /**
+     * appId (reverse-domain) 로 미니앱 조회.
+     * Analytics 이벤트 수신 시 앱 검증에 사용.
+     */
+    @Query("SELECT m FROM MiniApp m JOIN FETCH m.workspace WHERE m.appId = :appId")
+    java.util.Optional<MiniApp> findByAppId(@org.springframework.data.repository.query.Param("appId") String appId);
+
+    /**
+     * appId + status 조합으로 존재 여부 확인 (count 쿼리, 경량).
+     * Analytics 이벤트 수신 시 APPROVED 앱 여부 검증에 사용.
+     */
+    boolean existsByAppIdAndStatus(String appId, MiniAppStatus status);
 }

--- a/src/main/java/com/union/union/global/config/RedisConfig.java
+++ b/src/main/java/com/union/union/global/config/RedisConfig.java
@@ -15,6 +15,8 @@ import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
 @Configuration
 @EnableCaching
@@ -49,14 +51,28 @@ public class RedisConfig {
 
     @Bean
     public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
-        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofMinutes(5)) // 기본 TTL 5분
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(5))
                 .disableCachingNullValues()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
 
+        // 캐시별 TTL 개별 설정
+        Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
+
+        // 미니앱 목록 캐시 (기존)
+        cacheConfigurations.put("miniApps",        defaultConfig.entryTtl(Duration.ofMinutes(5)));
+        cacheConfigurations.put("popularMiniApps", defaultConfig.entryTtl(Duration.ofMinutes(5)));
+
+        // Analytics: appId 검증 캐시 (5분 — 앱 승인 상태 변경 반영 주기)
+        cacheConfigurations.put("analyticsAppId",  defaultConfig.entryTtl(Duration.ofMinutes(5)));
+
+        // Analytics: 요약 집계 캐시 (5분 — 대시보드 실시간성 vs DB 부하 균형)
+        cacheConfigurations.put("analyticsSummary", defaultConfig.entryTtl(Duration.ofMinutes(5)));
+
         return RedisCacheManager.builder(connectionFactory)
-                .cacheDefaults(config)
+                .cacheDefaults(defaultConfig)
+                .withInitialCacheConfigurations(cacheConfigurations)
                 .build();
     }
 }

--- a/src/main/java/com/union/union/global/infra/redis/RedisService.java
+++ b/src/main/java/com/union/union/global/infra/redis/RedisService.java
@@ -49,4 +49,9 @@ public class RedisService {
     public Set<Object> getTopRanks(String key, int limit) {
         return redisTemplate.opsForZSet().reverseRange(key, 0, Math.max(0, limit - 1));
     }
+
+    // 키 만료 시간 설정 (이미 존재하는 키의 TTL 갱신)
+    public void setExpire(String key, Duration timeout) {
+        redisTemplate.expire(key, timeout);
+    }
 }

--- a/src/main/java/com/union/union/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/union/union/global/security/config/SecurityConfig.java
@@ -55,6 +55,12 @@ public class SecurityConfig {
                 .requestMatchers("/auth/email/**").permitAll()
                 .requestMatchers("/api/v1/universities/**").permitAll()
 
+                // Analytics endpoints
+                // POST /events: iOS/Android 네이티브 앱 (User JWT, ROLE_USER)
+                .requestMatchers(HttpMethod.POST, "/api/v1/analytics/events").authenticated()
+                // GET summary/events: 퍼블리셔 대시보드 (@PreAuthorize 로 세부 인가)
+                .requestMatchers(HttpMethod.GET, "/api/v1/analytics/**").authenticated()
+
                 // MiniApp endpoints
                 .requestMatchers(HttpMethod.POST, "/mini-apps/*/launch").authenticated()
                 .requestMatchers(HttpMethod.POST, "/mini-apps").hasRole("PUBLISHER")


### PR DESCRIPTION
## 개요

미니앱에서 수집된 트래킹 이벤트를 수신·저장·집계하는 Analytics 도메인을 신규 구현합니다.
모든 실제 전송 및 PII 필터링은 네이티브 레이어에서 처리되며, 서버는 수신·검증·저장·집계를 담당합니다.

## 신규 도메인

### 엔티티
- `AnalyticsEvent` — 이벤트 원본 저장 (JSONB params, 복합 인덱스 7개)

### Repository (Native SQL)
- 이벤트 타입별 카운트
- 상위 화면뷰 / 커스텀 이벤트 / 에러 / 전환 목록
- `percentile_cont(0.5/0.95)` 성능 통계 (FCP, LCP, page_load, bridge_latency)
- 일별 추이 (KST 기준)

### API 엔드포인트
| 메서드 | 경로 | 인증 |
|--------|------|------|
| POST | `/api/v1/analytics/events` | User JWT |
| GET  | `/api/v1/analytics/apps/{appId}/summary` | Publisher/Admin JWT |
| GET  | `/api/v1/analytics/apps/{appId}/events` | Publisher/Admin JWT |

### 보안
- 멱등성: `X-Request-ID` Redis 키 (24h TTL)
- JWT hashedUserId 재검증: `SHA-256(userId:appId)` 서버 재계산
- appId 검증: APPROVED 상태 앱만 허용 (Redis 5분 캐시)
- 타임스탬프 범위: 과거 24h / 미래 5분 초과 거절
- Publisher 워크스페이스 인가: 자신의 앱만 조회 가능

## 기존 코드 변경
- `MiniApp`: `appId` 컬럼 추가 (unique, nullable)
- `MiniAppRepository`: `findByAppId`, `existsByAppIdAndStatus` 추가
- `SecurityConfig`: `/api/v1/analytics/**` 인증 규칙 등록
- `RedisConfig`: 캐시 TTL 개별 설정 추가
- `RedisService`: `setExpire()` 추가