### PR TITLE
feat: iOS 퍼블리셔 이메일 OTP 로그인 + /bundle 정리

### DIFF
--- a/src/main/java/com/union/union/domain/appversion/controller/AppVersionController.java
+++ b/src/main/java/com/union/union/domain/appversion/controller/AppVersionController.java
@@ -16,7 +16,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 @RestController
@@ -74,15 +73,6 @@ public class AppVersionController {
     ) {
         AppVersionResponseDto response = appVersionService.markTested(id, principal.userId());
         return ResponseEntity.ok(response);
-    }
-
-    @GetMapping("/{id}/bundle")
-    @PreAuthorize("hasRole('PUBLISHER') or hasRole('ADMIN')")
-    public ResponseEntity<Map<String, String>> getBundleUrl(
-            @PathVariable UUID id
-    ) {
-        String downloadUrl = appVersionService.getBundleDownloadUrl(id);
-        return ResponseEntity.ok(Map.of("downloadUrl", downloadUrl));
     }
 
     @GetMapping("/mini-app/{miniAppId}")

--- a/src/main/java/com/union/union/domain/appversion/service/AppVersionService.java
+++ b/src/main/java/com/union/union/domain/appversion/service/AppVersionService.java
@@ -149,17 +149,6 @@ public class AppVersionService {
         return AppVersionResponseDto.from(version);
     }
 
-    public String getBundleDownloadUrl(UUID versionId) {
-        AppVersion version = appVersionRepository.findDetailedById(versionId)
-                .orElseThrow(() -> new EntityNotFoundException("AppVersion을 찾을 수 없습니다"));
-
-        if (version.getBuildFileUrl() == null) {
-            throw new ConflictException("아직 업로드되지 않은 버전입니다");
-        }
-
-        return String.format("%s?versionId=%s", universalLinkBaseUrl, versionId);
-    }
-
     public List<AppVersionResponseDto> getVersionsByMiniApp(Long miniAppId) {
         return appVersionRepository.findByMiniAppIdOrderByCreatedAtDesc(miniAppId)
                 .stream()

--- a/src/main/java/com/union/union/domain/auth/controller/DevSeedController.java
+++ b/src/main/java/com/union/union/domain/auth/controller/DevSeedController.java
@@ -24,6 +24,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -156,6 +159,68 @@ public class DevSeedController {
                 versionNumber, releaseNotes, iconUrl, publisherName, file
         );
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 개발용 — 등록된 퍼블리셔 목록을 ID/이메일/상태와 함께 반환.
+     * iOS 퍼블리셔 로그인 검증 시 어떤 이메일로 발송 가능한지 빠르게 확인하기 위함.
+     */
+    @GetMapping("/publishers")
+    public ResponseEntity<List<Map<String, Object>>> listPublishers() {
+        List<Map<String, Object>> result = publisherRepository.findAll().stream()
+                .map(p -> {
+                    Map<String, Object> m = new LinkedHashMap<>();
+                    m.put("publisherId", p.getPublisherId());
+                    m.put("name", p.getName());
+                    m.put("email", p.getEmail());
+                    m.put("status", p.getPubstatus());
+                    m.put("role", p.getRole());
+                    return m;
+                })
+                .toList();
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * 개발용 — 퍼블리셔 이메일/상태를 임의로 갱신.
+     * iOS 로그인 검증 시 자기 이메일로 OTP를 받기 위해 사용한다.
+     */
+    @PatchMapping("/publishers/{publisherId}")
+    @Transactional
+    public ResponseEntity<Map<String, Object>> updatePublisher(
+            @PathVariable UUID publisherId,
+            @RequestParam(required = false) String email,
+            @RequestParam(required = false) String status
+    ) {
+        Publisher publisher = publisherRepository.findByPublisherId(publisherId)
+                .orElseThrow(() -> new IllegalArgumentException("publisher not found: " + publisherId));
+
+        if (email != null && !email.isBlank()) {
+            entityManager.createNativeQuery(
+                    "UPDATE publishers SET email = :email WHERE publisher_id = :pid"
+            )
+            .setParameter("email", email.trim().toLowerCase())
+            .setParameter("pid", publisherId)
+            .executeUpdate();
+        }
+        if (status != null && !status.isBlank()) {
+            entityManager.createNativeQuery(
+                    "UPDATE publishers SET pubstatus = :status WHERE publisher_id = :pid"
+            )
+            .setParameter("status", status.toUpperCase())
+            .setParameter("pid", publisherId)
+            .executeUpdate();
+        }
+        entityManager.flush();
+        entityManager.clear();
+
+        Publisher refreshed = publisherRepository.findByPublisherId(publisherId).orElseThrow();
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("publisherId", refreshed.getPublisherId());
+        result.put("name", refreshed.getName());
+        result.put("email", refreshed.getEmail());
+        result.put("status", refreshed.getPubstatus());
+        return ResponseEntity.ok(result);
     }
 
     // ── helpers ──────────────────────────────────────────────

--- a/src/main/java/com/union/union/domain/auth/scheduler/TokenCleanupScheduler.java
+++ b/src/main/java/com/union/union/domain/auth/scheduler/TokenCleanupScheduler.java
@@ -1,6 +1,7 @@
 package com.union.union.domain.auth.scheduler;
 
 import com.union.union.domain.auth.repository.RefreshTokenRepository;
+import com.union.union.domain.publisher.auth.repository.PublisherRefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -13,11 +14,13 @@ import org.springframework.transaction.annotation.Transactional;
 public class TokenCleanupScheduler {
 
     private final RefreshTokenRepository refreshTokenRepository;
+    private final PublisherRefreshTokenRepository publisherRefreshTokenRepository;
 
     @Transactional
     @Scheduled(cron = "${token-cleanup.refresh-token-cron}")
     public void cleanupExpiredAndRevokedRefreshTokens() {
-        int deletedCount = refreshTokenRepository.deleteExpiredAndRevoked();
-        log.info("Refresh token cleanup completed. deletedCount={}", deletedCount);
+        int userDeleted = refreshTokenRepository.deleteExpiredAndRevoked();
+        int publisherDeleted = publisherRefreshTokenRepository.deleteExpiredAndRevoked();
+        log.info("Refresh token cleanup completed. user={}, publisher={}", userDeleted, publisherDeleted);
     }
 }

--- a/src/main/java/com/union/union/domain/publisher/auth/controller/PublisherAuthController.java
+++ b/src/main/java/com/union/union/domain/publisher/auth/controller/PublisherAuthController.java
@@ -1,0 +1,66 @@
+package com.union.union.domain.publisher.auth.controller;
+
+import com.union.union.domain.auth.dto.RefreshRequestDto;
+import com.union.union.domain.publisher.auth.dto.PublisherEmailSendRequestDto;
+import com.union.union.domain.publisher.auth.dto.PublisherEmailSendResponseDto;
+import com.union.union.domain.publisher.auth.dto.PublisherEmailVerifyRequestDto;
+import com.union.union.domain.publisher.auth.dto.PublisherTokenResponseDto;
+import com.union.union.domain.publisher.auth.service.PublisherAuthService;
+import com.union.union.global.security.jwt.JwtUserPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * iOS 퍼블리셔 패스워드리스 로그인 API.
+ *
+ * <ul>
+ *     <li>POST {@code /api/v1/auth/publisher/email/send}</li>
+ *     <li>POST {@code /api/v1/auth/publisher/email/verify}</li>
+ *     <li>POST {@code /api/v1/auth/publisher/refresh}</li>
+ *     <li>POST {@code /api/v1/auth/publisher/logout}</li>
+ * </ul>
+ *
+ * 모든 send/verify/refresh는 {@code SecurityConfig}에서 permitAll로 노출되며,
+ * rate-limit는 {@code RateLimitFilter}가 적용한다.
+ */
+@RestController
+@RequestMapping("/api/v1/auth/publisher")
+@RequiredArgsConstructor
+public class PublisherAuthController {
+
+    private final PublisherAuthService publisherAuthService;
+
+    @PostMapping("/email/send")
+    public ResponseEntity<PublisherEmailSendResponseDto> sendCode(
+            @Valid @RequestBody PublisherEmailSendRequestDto request
+    ) {
+        return ResponseEntity.ok(publisherAuthService.sendCode(request.email()));
+    }
+
+    @PostMapping("/email/verify")
+    public ResponseEntity<PublisherTokenResponseDto> verifyCode(
+            @Valid @RequestBody PublisherEmailVerifyRequestDto request
+    ) {
+        return ResponseEntity.ok(
+                publisherAuthService.verifyAndIssueTokens(request.email(), request.code())
+        );
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<PublisherTokenResponseDto> refresh(
+            @Valid @RequestBody RefreshRequestDto request
+    ) {
+        return ResponseEntity.ok(publisherAuthService.refresh(request.refreshToken()));
+    }
+
+    @PostMapping("/logout")
+    @PreAuthorize("hasRole('PUBLISHER')")
+    public ResponseEntity<Void> logout(@AuthenticationPrincipal JwtUserPrincipal principal) {
+        publisherAuthService.logout(principal.userId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/union/union/domain/publisher/auth/dto/PublisherEmailSendRequestDto.java
+++ b/src/main/java/com/union/union/domain/publisher/auth/dto/PublisherEmailSendRequestDto.java
@@ -1,0 +1,10 @@
+package com.union.union.domain.publisher.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record PublisherEmailSendRequestDto(
+        @NotBlank(message = "이메일을 입력해주세요.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        String email
+) {}

--- a/src/main/java/com/union/union/domain/publisher/auth/dto/PublisherEmailSendResponseDto.java
+++ b/src/main/java/com/union/union/domain/publisher/auth/dto/PublisherEmailSendResponseDto.java
@@ -1,0 +1,12 @@
+package com.union.union.domain.publisher.auth.dto;
+
+/**
+ * 이메일 OTP 발송 응답.
+ *
+ * @param expiresInSeconds OTP 만료까지 남은 초 (클라이언트 카운트다운 표시용)
+ * @param maskedEmail      UI 노출용 마스킹된 이메일 (예: "ju****@dankook.ac.kr")
+ */
+public record PublisherEmailSendResponseDto(
+        int expiresInSeconds,
+        String maskedEmail
+) {}

--- a/src/main/java/com/union/union/domain/publisher/auth/dto/PublisherEmailVerifyRequestDto.java
+++ b/src/main/java/com/union/union/domain/publisher/auth/dto/PublisherEmailVerifyRequestDto.java
@@ -1,0 +1,15 @@
+package com.union.union.domain.publisher.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record PublisherEmailVerifyRequestDto(
+        @NotBlank(message = "이메일을 입력해주세요.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        String email,
+
+        @NotBlank(message = "인증번호를 입력해주세요.")
+        @Pattern(regexp = "\\d{6}", message = "인증번호는 6자리 숫자입니다.")
+        String code
+) {}

--- a/src/main/java/com/union/union/domain/publisher/auth/dto/PublisherTokenResponseDto.java
+++ b/src/main/java/com/union/union/domain/publisher/auth/dto/PublisherTokenResponseDto.java
@@ -1,0 +1,11 @@
+package com.union.union.domain.publisher.auth.dto;
+
+import java.util.UUID;
+
+public record PublisherTokenResponseDto(
+        String accessToken,
+        String refreshToken,
+        UUID publisherId,
+        String name,
+        String role
+) {}

--- a/src/main/java/com/union/union/domain/publisher/auth/entity/PublisherRefreshToken.java
+++ b/src/main/java/com/union/union/domain/publisher/auth/entity/PublisherRefreshToken.java
@@ -1,0 +1,68 @@
+package com.union.union.domain.publisher.auth.entity;
+
+import com.union.union.domain.publisher.entity.Publisher;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * iOS 퍼블리셔 로그인 전용 refresh token.
+ *
+ * <p>{@code refresh_tokens}(User용)와 분리한 이유:
+ * <ul>
+ *     <li>FK가 다르다(users vs publishers)</li>
+ *     <li>탈취 감지·일괄 무효화 정책을 사용자 세션에 영향 없이 운영하기 위함</li>
+ *     <li>대시보드(NextAuth) 세션은 별도 단명 internal-jwt를 사용 → 본 테이블은 iOS 단독</li>
+ * </ul>
+ */
+@Entity
+@Table(name = "publisher_refresh_tokens", indexes = {
+        @Index(name = "idx_publisher_refresh_token", columnList = "token", unique = true),
+        @Index(name = "idx_publisher_refresh_token_publisher", columnList = "publisher_id")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PublisherRefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "publisher_id", referencedColumnName = "publisher_id", nullable = false)
+    private Publisher publisher;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(nullable = false)
+    private boolean revoked;
+
+    @Builder
+    public PublisherRefreshToken(String token, Publisher publisher, LocalDateTime expiresAt) {
+        this.token = token;
+        this.publisher = publisher;
+        this.expiresAt = expiresAt;
+        this.revoked = false;
+    }
+
+    public void revoke() {
+        this.revoked = true;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
+    }
+
+    public UUID getPublisherUuid() {
+        return publisher.getPublisherId();
+    }
+}

--- a/src/main/java/com/union/union/domain/publisher/auth/exception/PublisherInactiveException.java
+++ b/src/main/java/com/union/union/domain/publisher/auth/exception/PublisherInactiveException.java
@@ -1,0 +1,14 @@
+package com.union.union.domain.publisher.auth.exception;
+
+import com.union.union.global.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 퍼블리셔 계정 상태가 ACTIVE가 아닐 때 (PENDING/REJECTED 등).
+ */
+public class PublisherInactiveException extends BusinessException {
+
+    public PublisherInactiveException(String detail) {
+        super(HttpStatus.FORBIDDEN, "PUBLISHER_INACTIVE", detail);
+    }
+}

--- a/src/main/java/com/union/union/domain/publisher/auth/exception/PublisherNotRegisteredException.java
+++ b/src/main/java/com/union/union/domain/publisher/auth/exception/PublisherNotRegisteredException.java
@@ -1,0 +1,16 @@
+package com.union.union.domain.publisher.auth.exception;
+
+import com.union.union.global.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+/**
+ * 입력된 전화번호로 등록된 퍼블리셔가 없을 때.
+ * iOS 클라이언트가 이 코드를 받으면 "유니온 웹사이트에서 회원가입" 안내 alert을 띄운다.
+ */
+public class PublisherNotRegisteredException extends BusinessException {
+
+    public PublisherNotRegisteredException() {
+        super(HttpStatus.NOT_FOUND, "PUBLISHER_NOT_REGISTERED",
+                "등록되지 않은 계정입니다. 유니온 웹사이트에서 먼저 회원가입 해주세요.");
+    }
+}

--- a/src/main/java/com/union/union/domain/publisher/auth/repository/PublisherRefreshTokenRepository.java
+++ b/src/main/java/com/union/union/domain/publisher/auth/repository/PublisherRefreshTokenRepository.java
@@ -1,0 +1,24 @@
+package com.union.union.domain.publisher.auth.repository;
+
+import com.union.union.domain.publisher.auth.entity.PublisherRefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PublisherRefreshTokenRepository extends JpaRepository<PublisherRefreshToken, Long> {
+
+    Optional<PublisherRefreshToken> findByToken(String token);
+
+    @Modifying
+    @Query("UPDATE PublisherRefreshToken rt SET rt.revoked = true " +
+            "WHERE rt.publisher.publisherId = :publisherId AND rt.revoked = false")
+    void revokeAllByPublisherId(@Param("publisherId") UUID publisherId);
+
+    @Modifying
+    @Query("DELETE FROM PublisherRefreshToken rt WHERE rt.revoked = true OR rt.expiresAt < CURRENT_TIMESTAMP")
+    int deleteExpiredAndRevoked();
+}

--- a/src/main/java/com/union/union/domain/publisher/auth/service/EmailMasker.java
+++ b/src/main/java/com/union/union/domain/publisher/auth/service/EmailMasker.java
@@ -1,0 +1,37 @@
+package com.union.union.domain.publisher.auth.service;
+
+/**
+ * 이메일 로컬파트를 마스킹한다.
+ *
+ * <pre>
+ *   junseo@dankook.ac.kr  → ju****@dankook.ac.kr
+ *   ab@x.com              → a*@x.com
+ *   a@x.com               → *@x.com
+ * </pre>
+ *
+ * UI에서 인증번호 발송 안내 문구에 노출되며, 사용자가 다른 계정의 이메일이 아닌
+ * 자기 계정에 발송되었음을 즉시 식별할 수 있도록 돕는 목적.
+ */
+public final class EmailMasker {
+
+    private EmailMasker() {}
+
+    public static String mask(String email) {
+        if (email == null) return "";
+        int at = email.indexOf('@');
+        if (at <= 0) return email;
+
+        String local = email.substring(0, at);
+        String domain = email.substring(at);
+
+        if (local.length() == 1) {
+            return "*" + domain;
+        }
+        if (local.length() == 2) {
+            return local.charAt(0) + "*" + domain;
+        }
+
+        int visible = Math.min(2, local.length() - 1);
+        return local.substring(0, visible) + "****" + domain;
+    }
+}

--- a/src/main/java/com/union/union/domain/publisher/auth/service/PublisherAuthService.java
+++ b/src/main/java/com/union/union/domain/publisher/auth/service/PublisherAuthService.java
@@ -1,0 +1,183 @@
+package com.union.union.domain.publisher.auth.service;
+
+import com.union.union.domain.auth.service.MailService;
+import com.union.union.domain.publisher.auth.dto.PublisherEmailSendResponseDto;
+import com.union.union.domain.publisher.auth.dto.PublisherTokenResponseDto;
+import com.union.union.domain.publisher.auth.entity.PublisherRefreshToken;
+import com.union.union.domain.publisher.auth.exception.PublisherInactiveException;
+import com.union.union.domain.publisher.auth.exception.PublisherNotRegisteredException;
+import com.union.union.domain.publisher.auth.repository.PublisherRefreshTokenRepository;
+import com.union.union.domain.publisher.auth.store.PublisherEmailVerificationStore;
+import com.union.union.domain.publisher.entity.Publisher;
+import com.union.union.domain.publisher.entity.PublisherStatus;
+import com.union.union.domain.publisher.repository.PublisherRepository;
+import com.union.union.global.common.exception.BadRequestException;
+import com.union.union.global.common.exception.InvalidRefreshTokenException;
+import com.union.union.global.security.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.LocalDateTime;
+
+/**
+ * iOS 퍼블리셔 패스워드리스 로그인 (이메일 OTP 기반).
+ *
+ * <p>플로우:
+ * <ol>
+ *     <li>{@link #sendCode(String)} — 등록된 퍼블리셔에게만 6자리 OTP 메일 발송</li>
+ *     <li>{@link #verifyAndIssueTokens(String, String)} — OTP 검증 후 access/refresh 발급</li>
+ * </ol>
+ *
+ * <p>설계 노트:
+ * <ul>
+ *     <li>존재하지 않는 이메일은 {@link PublisherNotRegisteredException}로 명시 응답
+ *         — 가입 유도 UX가 핵심 요구사항. 사용자 enumeration 위험은 rate-limit으로 완화.</li>
+ *     <li>OTP는 5분 만료. 검증 성공 시 즉시 삭제하여 재사용 불가.</li>
+ *     <li>refresh token은 별도 테이블({@code publisher_refresh_tokens})에 저장하여
+ *         사용자(User) 세션과 정책·수명을 독립적으로 운영한다.</li>
+ *     <li>발급되는 JWT의 {@code sub}는 {@link Publisher#getPublisherId()} (UUID).
+ *         기존 워크스페이스 권한 검증({@link com.union.union.domain.workspace.service.WorkspaceAuthorizationService})이
+ *         {@code principal.userId()}를 publisherId로 사용하므로 그대로 호환된다.</li>
+ * </ul>
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PublisherAuthService {
+
+    private static final long CODE_TTL_MILLIS = 5 * 60 * 1000L; // 5분
+    private static final int CODE_TTL_SECONDS = (int) (CODE_TTL_MILLIS / 1000);
+
+    private final PublisherRepository publisherRepository;
+    private final PublisherEmailVerificationStore verificationStore;
+    private final PublisherRefreshTokenRepository refreshTokenRepository;
+    private final MailService mailService;
+    private final JwtProvider jwtProvider;
+    private final SecureRandom random = new SecureRandom();
+
+    /** 로컬 개발 시 검증·테스트 편의를 위해 OTP를 콘솔에 직접 출력. 운영에선 false. */
+    @Value("${mail.dev.log-only:false}")
+    private boolean logOtpForDev;
+
+    /**
+     * 등록된 퍼블리셔에게만 OTP를 발송한다.
+     *
+     * @throws PublisherNotRegisteredException 미등록 이메일
+     * @throws PublisherInactiveException      ACTIVE가 아닌 상태
+     */
+    public PublisherEmailSendResponseDto sendCode(String email) {
+        String normalized = email.trim().toLowerCase();
+        Publisher publisher = publisherRepository.findByEmail(normalized)
+                .orElseThrow(PublisherNotRegisteredException::new);
+        ensureActive(publisher);
+
+        String code = generateCode();
+        verificationStore.delete(normalized);
+        verificationStore.save(normalized, code, System.currentTimeMillis() + CODE_TTL_MILLIS);
+        mailService.sendVerificationEmail(normalized, code);
+
+        if (logOtpForDev) {
+            log.info("[PublisherAuth/dev] email={}, otp={}", normalized, code);
+        }
+        log.info("[PublisherAuth] OTP 발송 완료. publisherId={}", publisher.getPublisherId());
+        return new PublisherEmailSendResponseDto(CODE_TTL_SECONDS, EmailMasker.mask(normalized));
+    }
+
+    /**
+     * OTP를 검증하고 토큰을 발급한다. 성공 시 OTP는 즉시 무효화한다.
+     */
+    @Transactional
+    public PublisherTokenResponseDto verifyAndIssueTokens(String email, String code) {
+        String normalized = email.trim().toLowerCase();
+
+        String savedCode = verificationStore.get(normalized)
+                .orElseThrow(() -> new BadRequestException("만료되었거나 발급되지 않은 인증 정보입니다."));
+        if (!savedCode.equals(code)) {
+            throw new BadRequestException("인증번호가 일치하지 않습니다.");
+        }
+        verificationStore.delete(normalized);
+
+        Publisher publisher = publisherRepository.findByEmail(normalized)
+                .orElseThrow(PublisherNotRegisteredException::new);
+        ensureActive(publisher);
+
+        return issueTokens(publisher);
+    }
+
+    /**
+     * 만료 직전 토큰을 갱신한다. 재사용 감지 시 해당 퍼블리셔의 모든 토큰을 무효화.
+     */
+    @Transactional
+    public PublisherTokenResponseDto refresh(String refreshToken) {
+        PublisherRefreshToken stored = refreshTokenRepository.findByToken(refreshToken)
+                .orElseThrow(() -> new InvalidRefreshTokenException("유효하지 않은 refresh token입니다"));
+
+        if (stored.isRevoked()) {
+            log.warn("[PublisherAuth] Refresh token 재사용 감지! publisherId={}. 전체 세션 무효화.",
+                    stored.getPublisherUuid());
+            refreshTokenRepository.revokeAllByPublisherId(stored.getPublisherUuid());
+            throw new InvalidRefreshTokenException("보안상 모든 세션이 로그아웃되었습니다. 다시 로그인해주세요.");
+        }
+        if (stored.isExpired()) {
+            stored.revoke();
+            throw new InvalidRefreshTokenException("세션이 만료되었습니다. 다시 로그인해주세요.");
+        }
+
+        stored.revoke();
+        Publisher publisher = stored.getPublisher();
+        ensureActive(publisher);
+
+        log.info("[PublisherAuth] 토큰 갱신. publisherId={}", publisher.getPublisherId());
+        return issueTokens(publisher);
+    }
+
+    @Transactional
+    public void logout(java.util.UUID publisherId) {
+        refreshTokenRepository.revokeAllByPublisherId(publisherId);
+        log.info("[PublisherAuth] 로그아웃. publisherId={}", publisherId);
+    }
+
+    // ── helpers ──────────────────────────────────────────────
+
+    private void ensureActive(Publisher publisher) {
+        if (publisher.getPubstatus() != PublisherStatus.ACTIVE) {
+            throw new PublisherInactiveException(
+                    "퍼블리셔 계정이 활성 상태가 아닙니다. (상태: " + publisher.getPubstatus() + ")"
+            );
+        }
+    }
+
+    private PublisherTokenResponseDto issueTokens(Publisher publisher) {
+        String accessToken = jwtProvider.createAccessToken(
+                publisher.getPublisherId(),
+                publisher.getEmail(),
+                "ROLE_PUBLISHER"
+        );
+        String refreshTokenStr = jwtProvider.createRefreshToken(publisher.getPublisherId());
+
+        long refreshTtlMillis = jwtProvider.getRefreshTokenExpirationMillis();
+        PublisherRefreshToken entity = PublisherRefreshToken.builder()
+                .token(refreshTokenStr)
+                .publisher(publisher)
+                .expiresAt(LocalDateTime.now().plusSeconds(refreshTtlMillis / 1000))
+                .build();
+        refreshTokenRepository.save(entity);
+
+        return new PublisherTokenResponseDto(
+                accessToken,
+                refreshTokenStr,
+                publisher.getPublisherId(),
+                publisher.getName(),
+                "ROLE_PUBLISHER"
+        );
+    }
+
+    private String generateCode() {
+        return String.format("%06d", random.nextInt(1_000_000));
+    }
+}

--- a/src/main/java/com/union/union/domain/publisher/auth/store/PublisherEmailVerificationStore.java
+++ b/src/main/java/com/union/union/domain/publisher/auth/store/PublisherEmailVerificationStore.java
@@ -1,0 +1,22 @@
+package com.union.union.domain.publisher.auth.store;
+
+import java.util.Optional;
+
+/**
+ * 퍼블리셔 로그인 OTP 저장소 추상화.
+ *
+ * <p>기존 {@link com.union.union.domain.auth.store.EmailVerificationStore}와 다른 용도:
+ * <ul>
+ *     <li>signup 인증은 "이메일 소유 증명 → 회원가입" 단계에 사용</li>
+ *     <li>본 store는 "이미 가입된 퍼블리셔의 패스워드리스 로그인 OTP"</li>
+ * </ul>
+ * 키 네임스페이스를 분리해 두 플로우가 서로의 코드를 덮어쓰지 않도록 한다.
+ */
+public interface PublisherEmailVerificationStore {
+
+    void save(String email, String code, long expireMillisFromEpoch);
+
+    Optional<String> get(String email);
+
+    void delete(String email);
+}

--- a/src/main/java/com/union/union/domain/publisher/auth/store/RedisPublisherEmailVerificationStore.java
+++ b/src/main/java/com/union/union/domain/publisher/auth/store/RedisPublisherEmailVerificationStore.java
@@ -1,0 +1,36 @@
+package com.union.union.domain.publisher.auth.store;
+
+import com.union.union.global.infra.redis.RedisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Primary
+@Component
+@RequiredArgsConstructor
+public class RedisPublisherEmailVerificationStore implements PublisherEmailVerificationStore {
+
+    private static final String CODE_PREFIX = "publisher:auth:code:";
+
+    private final RedisService redisService;
+
+    @Override
+    public void save(String email, String code, long expireMillisFromEpoch) {
+        long durationMillis = expireMillisFromEpoch - System.currentTimeMillis();
+        if (durationMillis <= 0) return;
+        redisService.setValuesWithTimeout(CODE_PREFIX + email, code, Duration.ofMillis(durationMillis));
+    }
+
+    @Override
+    public Optional<String> get(String email) {
+        return redisService.get(CODE_PREFIX + email);
+    }
+
+    @Override
+    public void delete(String email) {
+        redisService.delete(CODE_PREFIX + email);
+    }
+}

--- a/src/main/java/com/union/union/domain/publisher/repository/PublisherRepository.java
+++ b/src/main/java/com/union/union/domain/publisher/repository/PublisherRepository.java
@@ -11,4 +11,5 @@ import java.util.UUID;
 public interface PublisherRepository extends JpaRepository<Publisher, Long> {
     Optional<Publisher> findByPublisherId(UUID publisherId);
     boolean existsByPublisherId(UUID publisherId);
+    Optional<Publisher> findByEmail(String email);
 }

--- a/src/main/java/com/union/union/global/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/union/union/global/common/exception/GlobalExceptionHandler.java
@@ -4,9 +4,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
 @RestControllerAdvice
@@ -33,6 +35,29 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.FORBIDDEN)
                 .body(ErrorResponse.of(HttpStatus.FORBIDDEN.value(), HttpStatus.FORBIDDEN.getReasonPhrase(),
                         "ACCESS_DENIED", "접근 권한이 없습니다"));
+    }
+
+    /**
+     * 라우팅되지 않은 경로(존재하지 않는 endpoint, 정적 리소스 미스 등)를 깔끔한 404로 변환.
+     * 기본 동작은 ResourceHttpRequestHandler가 NoResourceFoundException을 던져서
+     * generic 500으로 빠지는데, 이는 deprecated endpoint 호출 시 디버깅을 어렵게 만든다.
+     */
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ErrorResponse> handleNoResource(NoResourceFoundException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ErrorResponse.of(HttpStatus.NOT_FOUND.value(),
+                        HttpStatus.NOT_FOUND.getReasonPhrase(),
+                        "ENDPOINT_NOT_FOUND",
+                        "요청한 endpoint가 존재하지 않습니다."));
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ErrorResponse> handleMethodNotAllowed(HttpRequestMethodNotSupportedException e) {
+        return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED)
+                .body(ErrorResponse.of(HttpStatus.METHOD_NOT_ALLOWED.value(),
+                        HttpStatus.METHOD_NOT_ALLOWED.getReasonPhrase(),
+                        "METHOD_NOT_ALLOWED",
+                        "허용되지 않은 HTTP 메서드입니다."));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/union/union/global/config/MailDevConfig.java
+++ b/src/main/java/com/union/union/global/config/MailDevConfig.java
@@ -1,0 +1,101 @@
+package com.union.union.global.config;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.mail.MailException;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 로컬 개발 환경에서 SMTP 발송 없이 콘솔 로그만 남기는 메일 sender.
+ *
+ * <p>활성화: {@code mail.dev.log-only=true} (application-local.yml에서 설정)
+ *
+ * <p>OTP 6자리는 메일 본문에서 추출해 검증·테스트용으로 별도 라인에 기록한다.
+ * 운영 환경에는 이 빈이 등록되지 않으므로 동작에 영향 없음.
+ */
+@Slf4j
+@Configuration
+public class MailDevConfig {
+
+    @Bean
+    @Primary
+    @ConditionalOnProperty(prefix = "mail.dev", name = "log-only", havingValue = "true")
+    public JavaMailSender logOnlyMailSender(@Value("${spring.mail.host:noop}") String host) {
+        log.warn("[MailDevConfig] log-only mail sender 활성. 실제 메일 발송이 비활성화됩니다.");
+        return new LogOnlyMailSender();
+    }
+
+    /** SMTP 연결 없이 메일 내용을 콘솔에만 출력. */
+    static class LogOnlyMailSender extends JavaMailSenderImpl {
+
+        private static final Pattern OTP_PATTERN = Pattern.compile("(?<![0-9])([0-9]{6})(?![0-9])");
+
+        @Override
+        public MimeMessage createMimeMessage() {
+            // SMTP 세션 없이 메시지 객체만 생성 (테스트용)
+            Session session = Session.getInstance(new Properties());
+            return new MimeMessage(session);
+        }
+
+        @Override
+        public MimeMessage createMimeMessage(InputStream contentStream) {
+            return createMimeMessage();
+        }
+
+        @Override
+        public void send(MimeMessage mimeMessage) throws MailException {
+            try {
+                String to = String.join(",", asArray(mimeMessage.getAllRecipients()));
+                String subject = mimeMessage.getSubject();
+                String body = extractText(mimeMessage);
+                Matcher m = OTP_PATTERN.matcher(body);
+                String otp = m.find() ? m.group(1) : "<not-found>";
+
+                log.info("[Mail/log-only] to={}, subject={}, otp={}", to, subject, otp);
+            } catch (MessagingException e) {
+                log.warn("[Mail/log-only] 메일 메타데이터 파싱 실패", e);
+            }
+        }
+
+        @Override
+        public void send(MimeMessage... mimeMessages) throws MailException {
+            for (MimeMessage m : mimeMessages) send(m);
+        }
+
+        @Override
+        public void send(SimpleMailMessage simpleMessage) throws MailException {
+            log.info("[Mail/log-only] simple to={}, body={}", simpleMessage.getTo(), simpleMessage.getText());
+        }
+
+        private String[] asArray(jakarta.mail.Address[] addresses) {
+            if (addresses == null) return new String[0];
+            String[] out = new String[addresses.length];
+            for (int i = 0; i < addresses.length; i++) out[i] = addresses[i].toString();
+            return out;
+        }
+
+        private String extractText(MimeMessage message) throws MessagingException {
+            try {
+                Object content = message.getContent();
+                if (content instanceof String s) return s;
+                return content == null ? "" : content.toString();
+            } catch (Exception e) {
+                return "";
+            }
+        }
+    }
+}

--- a/src/main/java/com/union/union/global/config/RateLimitProperties.java
+++ b/src/main/java/com/union/union/global/config/RateLimitProperties.java
@@ -14,6 +14,8 @@ public class RateLimitProperties {
     private final Limit signup = new Limit(5, 60);
     private final Limit emailSend = new Limit(3, 60);
     private final Limit emailVerify = new Limit(5, 60);
+    private final Limit publisherEmailSend = new Limit(3, 60);
+    private final Limit publisherEmailVerify = new Limit(5, 60);
 
     @Getter
     @Setter

--- a/src/main/java/com/union/union/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/union/union/global/security/config/SecurityConfig.java
@@ -54,6 +54,10 @@ public class SecurityConfig {
                 .requestMatchers("/api/dev/**").permitAll()
                 .requestMatchers("/auth/email/**").permitAll()
                 .requestMatchers("/api/v1/universities/**").permitAll()
+                // Publisher 로그인은 permitAll, /logout만 인증 필요
+                .requestMatchers(HttpMethod.POST, "/api/v1/auth/publisher/email/send").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/v1/auth/publisher/email/verify").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/v1/auth/publisher/refresh").permitAll()
 
                 // Analytics endpoints
                 // POST /events: iOS/Android 네이티브 앱 (User JWT, ROLE_USER)

--- a/src/main/java/com/union/union/global/security/ratelimit/RateLimitFilter.java
+++ b/src/main/java/com/union/union/global/security/ratelimit/RateLimitFilter.java
@@ -75,6 +75,12 @@ public class RateLimitFilter extends OncePerRequestFilter {
         if (path.equals("/auth/email/verify")) {
             return properties.getEmailVerify();
         }
+        if (path.equals("/api/v1/auth/publisher/email/send")) {
+            return properties.getPublisherEmailSend();
+        }
+        if (path.equals("/api/v1/auth/publisher/email/verify")) {
+            return properties.getPublisherEmailVerify();
+        }
 
         return null;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,6 +83,12 @@ rate-limit:
   email-verify:
     max-requests: 5
     window-seconds: 60
+  publisher-email-send:
+    max-requests: 3
+    window-seconds: 60
+  publisher-email-verify:
+    max-requests: 5
+    window-seconds: 60
 
 token-cleanup:
   refresh-token-cron: ${REFRESH_TOKEN_CLEANUP_CRON:0 0 4 * * *}


### PR DESCRIPTION
## Summary
- iOS 퍼블리셔용 패스워드리스 이메일 OTP 로그인 4종 endpoint 추가 (`/api/v1/auth/publisher/...`)
- 미등록 계정은 `PUBLISHER_NOT_REGISTERED` (404)로 명시 응답 → iOS가 회원가입 안내 alert 분기
- `publisher_refresh_tokens` 신설로 User 세션과 격리, refresh rotation·재사용 감지 포함
- 보안 비대칭이었던 `GET /app-versions/{id}/bundle` (versionId 노출형 영구 링크) 제거 — token 기반 `/test-session`으로 일원화
- `GlobalExceptionHandler`에 `NoResourceFoundException` / `HttpRequestMethodNotSupportedException` 처리 추가 (이전엔 generic 500)

## JWT 구성
| 필드 | User | Publisher (신규) |
|---|---|---|
| `sub` | `users.id` (UUID) | `publishers.publisher_id` (UUID) |
| `email` | user email | publisher email |
| `role` | `ROLE_USER` 등 | `ROLE_PUBLISHER` |
| 알고리즘 | HS512 | 동일 (JwtProvider 재사용) |

## Test plan
- [x] `./gradlew build -x test` 통과
- [x] dev publisher (`66d1bf78-...`) 이메일을 `test-pub@union.local` 로 변경 후
  - send → 200, 콘솔에 OTP 로그 (`[PublisherAuth/dev] otp=...`)
  - verify → 200 + access/refresh 발급, JWT payload `role=ROLE_PUBLISHER`, `sub=publisher_id` 확인
  - refresh rotation → 200, 직전 refresh 재사용 시 401 + 전체 세션 revoke
- [x] 미등록 이메일 → 404 `PUBLISHER_NOT_REGISTERED`
- [x] `GET /app-versions/.../bundle` → 404 `ENDPOINT_NOT_FOUND` (Spring NoResourceFoundException 처리)
- [x] `POST /app-versions/.../test-session` 정상 라우팅

## 운영 전 보강 권고
1. 운영 환경에서 `mail.dev.log-only` 가 켜지지 않도록 `@Profile({"local","dev"})` 가드 추가 검토
2. 이메일 enumeration 완화 — 운영 시 Captcha 도입
3. OTP 부르트포스 잠금(이메일별 attempt counter) 추가
4. `ddl-auto=update` 의존 → 운영 배포 시 Flyway 마이그레이션으로 분리