### PR TITLE
feat: publisher 전체 워크스페이스 미니앱 합본 조회 지원

### DIFF
--- a/src/main/java/com/union/union/domain/miniapp/repository/MiniAppRepository.java
+++ b/src/main/java/com/union/union/domain/miniapp/repository/MiniAppRepository.java
@@ -34,6 +34,17 @@ public interface MiniAppRepository extends JpaRepository<MiniApp, Long> {
     @Query("SELECT m FROM MiniApp m JOIN FETCH m.workspace WHERE m.workspace.workspaceId = :workspaceId")
     List<MiniApp> findByWorkspace_WorkspaceId(@Param("workspaceId") UUID workspaceId);
 
+    /**
+     * 특정 publisher가 멤버인 모든 워크스페이스의 미니앱을 조회.
+     * iOS publisher 전용 화면("내가 업로드 한 앱")에서 사용.
+     */
+    @Query("SELECT DISTINCT m FROM MiniApp m " +
+           "JOIN FETCH m.workspace w " +
+           "JOIN WorkspaceMember wm ON wm.workspace.workspaceId = w.workspaceId " +
+           "WHERE wm.publisher.publisherId = :publisherId " +
+           "ORDER BY m.id DESC")
+    List<MiniApp> findByPublisherMembership(@Param("publisherId") UUID publisherId);
+
     @Query("SELECT m FROM MiniApp m JOIN FETCH m.workspace " +
            "WHERE m.status = :status AND m.id IN (" +
            "  SELECT u.miniAppId FROM MiniAppUsage u " +

--- a/src/main/java/com/union/union/domain/miniapp/service/MiniAppService.java
+++ b/src/main/java/com/union/union/domain/miniapp/service/MiniAppService.java
@@ -182,6 +182,16 @@ public class MiniAppService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * publisher가 속한 모든 워크스페이스의 미니앱을 합쳐 반환 (iOS publisher 전용 페이지).
+     */
+    public List<MiniAppResponseDto> getMiniAppsByPublisher(UUID publisherId) {
+        return miniAppRepository.findByPublisherMembership(publisherId)
+                .stream()
+                .map(MiniAppResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
     @Transactional
     public String getLaunchUrl(Long id, UUID userId) {
         MiniApp miniApp = miniAppRepository.findById(id)

--- a/src/main/java/com/union/union/domain/publisher/controller/PublisherController.java
+++ b/src/main/java/com/union/union/domain/publisher/controller/PublisherController.java
@@ -25,9 +25,14 @@ public class PublisherController {
     @GetMapping("/me/mini-apps")
     @PreAuthorize("hasRole('PUBLISHER')")
     public ResponseEntity<List<MiniAppResponseDto>> getMyMiniApps(
-            @RequestParam UUID workspaceId,
+            @RequestParam(required = false) UUID workspaceId,
             @AuthenticationPrincipal JwtUserPrincipal principal
     ) {
+        if (workspaceId == null) {
+            // workspaceId 미지정 → publisher가 속한 모든 워크스페이스의 미니앱 반환
+            List<MiniAppResponseDto> response = miniAppService.getMiniAppsByPublisher(principal.userId());
+            return ResponseEntity.ok(response);
+        }
         workspaceAuthorizationService.validateMembership(workspaceId, principal.userId());
         List<MiniAppResponseDto> response = miniAppService.getMiniAppsByWorkspace(workspaceId);
         return ResponseEntity.ok(response);


### PR DESCRIPTION
## Summary
- `GET /publishers/me/mini-apps` 의 `workspaceId` 파라미터를 optional 로 변경
- 파라미터 미지정 시, 인증된 publisher 가 속한 **모든 워크스페이스의 미니앱**을 합쳐서 반환
- iOS publisher 전용 화면("내가 업로드한 앱")에서 워크스페이스 단위로 호출하지 않고 한 번에 전체 목록을 받기 위함

## 변경 내역
- `MiniAppRepository.findByPublisherMembership(publisherId)` 신설 — `WorkspaceMember` 조인 + `JOIN FETCH workspace`, `id DESC` 정렬
- `MiniAppService.getMiniAppsByPublisher(publisherId)` 래퍼 추가
- `PublisherController.getMyMiniApps`: `workspaceId` 가 `null` 이면 신규 메서드 호출, 있으면 기존 동작 유지 (하위 호환)

## 관련 PR
- iOS: dku-union/union-ios#11

## Test plan
- [ ] `GET /publishers/me/mini-apps` (파라미터 없이) → publisher 가 속한 모든 워크스페이스 미니앱 반환
- [ ] `GET /publishers/me/mini-apps?workspaceId=...` → 기존처럼 해당 워크스페이스만 반환 (멤버십 검증 포함)
- [ ] 멤버가 아닌 워크스페이스의 미니앱은 결과에 포함되지 않음
- [ ] 중복 워크스페이스 멤버십이 있어도 미니앱이 중복되지 않음 (`DISTINCT`)