### PR TITLE
fix: Internal JWT(대시보드) admin 심사 결정 시 reviewer null 허용

### DIFF
--- a/src/main/java/com/union/union/domain/review/service/ReviewService.java
+++ b/src/main/java/com/union/union/domain/review/service/ReviewService.java
@@ -16,6 +16,7 @@ import com.union.union.domain.workspace.service.WorkspaceAuthorizationService;
 import com.union.union.global.common.exception.BadRequestException;
 import com.union.union.global.common.exception.ConflictException;
 import com.union.union.global.common.exception.EntityNotFoundException;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
@@ -92,8 +93,7 @@ public class ReviewService {
         Review review = reviewRepository.findDetailedById(reviewId)
                 .orElseThrow(() -> new EntityNotFoundException("Review를 찾을 수 없습니다"));
 
-        User admin = userRepository.findById(adminId)
-                .orElseThrow(() -> new EntityNotFoundException("관리자를 찾을 수 없습니다"));
+        User admin = userRepository.findById(adminId).orElse(null);
 
         review.decide(admin, request.verdict(), request.reason());
 
@@ -122,8 +122,7 @@ public class ReviewService {
             throw new BadRequestException("IN_REVIEW 상태가 아닙니다. 현재 상태: " + version.getStatus());
         }
 
-        User admin = userRepository.findById(adminId)
-                .orElseThrow(() -> new EntityNotFoundException("관리자를 찾을 수 없습니다"));
+        User admin = userRepository.findById(adminId).orElse(null);
 
         Review review = reviewRepository.findDetailedByVersionIdAndVerdict(versionId, Verdict.PENDING)
                 .orElseGet(() -> {


### PR DESCRIPTION
Internal JWT의 sub는 publisherId라 users 테이블에 없어 EntityNotFoundException 발생. reviewer_id는 nullable이므로 orElse(null)로 처리하여 결정 진행되도록 수정.