### PR TITLE
fix/feat(review,cdn): Review PK + CDN URL 인코딩 + GET /reviews/mine

### DIFF
--- a/src/main/java/com/union/union/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/union/union/domain/review/controller/ReviewController.java
@@ -41,6 +41,19 @@ public class ReviewController {
         return ResponseEntity.ok(response);
     }
 
+    /**
+     * 현재 로그인된 publisher 가 멤버인 모든 워크스페이스의 심사 이력.
+     * 반드시 {@code /{id}} 매핑보다 먼저 선언되어 path variable 충돌(`mine` → UUID 변환 실패)을 막는다.
+     */
+    @GetMapping("/mine")
+    @PreAuthorize("hasRole('PUBLISHER') or hasRole('ADMIN')")
+    public ResponseEntity<List<ReviewResponseDto>> getMyReviews(
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        List<ReviewResponseDto> response = reviewService.getMyReviews(principal.userId());
+        return ResponseEntity.ok(response);
+    }
+
     @GetMapping("/{id}")
     @PreAuthorize("hasRole('ADMIN')")
     public ResponseEntity<ReviewResponseDto> getReview(@PathVariable UUID id) {

--- a/src/main/java/com/union/union/domain/review/entity/Review.java
+++ b/src/main/java/com/union/union/domain/review/entity/Review.java
@@ -20,7 +20,7 @@ public class Review extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "review_id", columnDefinition = "uuid")
+    @Column(name = "id", columnDefinition = "uuid")
     private UUID id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/union/union/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/union/union/domain/review/repository/ReviewRepository.java
@@ -4,6 +4,8 @@ import com.union.union.domain.review.entity.Review;
 import com.union.union.domain.review.entity.Verdict;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -22,4 +24,19 @@ public interface ReviewRepository extends JpaRepository<Review, UUID> {
 
     @EntityGraph(attributePaths = {"version", "version.miniApp", "version.miniApp.workspace", "reviewer"})
     Optional<Review> findDetailedById(UUID id);
+
+    /**
+     * publisher 가 멤버인 모든 워크스페이스의 모든 심사 이력. dashboard "심사 현황" 페이지용.
+     * BaseEntity 의 createdAt 은 reviews 테이블에서 submitted_at 컬럼으로 매핑됨.
+     */
+    @Query("SELECT DISTINCT r FROM Review r " +
+           "JOIN FETCH r.version v " +
+           "JOIN FETCH v.miniApp ma " +
+           "JOIN FETCH ma.workspace w " +
+           "LEFT JOIN FETCH w.owner " +
+           "LEFT JOIN FETCH r.reviewer " +
+           "JOIN WorkspaceMember wm ON wm.workspace.workspaceId = w.workspaceId " +
+           "WHERE wm.publisher.publisherId = :publisherId " +
+           "ORDER BY r.createdAt DESC")
+    List<Review> findAllByPublisherMembership(@Param("publisherId") UUID publisherId);
 }

--- a/src/main/java/com/union/union/domain/review/service/ReviewService.java
+++ b/src/main/java/com/union/union/domain/review/service/ReviewService.java
@@ -69,6 +69,14 @@ public class ReviewService {
                 .collect(Collectors.toList());
     }
 
+    /** publisher 가 속한 모든 워크스페이스의 모든 심사 이력. dashboard "심사 현황" 페이지용. */
+    public List<ReviewResponseDto> getMyReviews(UUID publisherId) {
+        return reviewRepository.findAllByPublisherMembership(publisherId)
+                .stream()
+                .map(ReviewResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
     public ReviewResponseDto getReview(UUID reviewId) {
         Review review = reviewRepository.findDetailedById(reviewId)
                 .orElseThrow(() -> new EntityNotFoundException("Review를 찾을 수 없습니다"));

--- a/src/main/java/com/union/union/global/infra/gcs/GcsService.java
+++ b/src/main/java/com/union/union/global/infra/gcs/GcsService.java
@@ -13,9 +13,11 @@ import org.springframework.stereotype.Service;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.util.UriUtils;
 
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Base64;
@@ -89,7 +91,11 @@ public class GcsService {
      * CDN Signed URL 생성 (HMAC-SHA1)
      */
     private String generateCdnSignedUrl(String objectPath, long expirationSeconds) {
-        String urlPrefix = cdnProperties.baseUrl() + "/" + objectPath;
+        // 한글 등 non-ASCII 문자가 path에 포함되면 클라이언트가 percent-encode 후 요청한다.
+        // CDN은 요청 시점의 (encoded) path 기준으로 서명을 검증하므로,
+        // 동일하게 encoded 형태로 서명해야 mismatch 가 발생하지 않는다. (`/` 는 그대로 보존)
+        String encodedPath = UriUtils.encodePath(objectPath, StandardCharsets.UTF_8);
+        String urlPrefix = cdnProperties.baseUrl() + "/" + encodedPath;
         long expiration = Instant.now().getEpochSecond() + expirationSeconds;
 
         String urlToSign = urlPrefix + "?Expires=" + expiration + "&KeyName=" + cdnProperties.keyName();


### PR DESCRIPTION
## Summary

- **Review PK 매핑 정정 (fix)**
  - `Review.@Column(name = "review_id")` → `"id"`
  - 실제 DB PK 컬럼은 `id`. legacy `review_id` 컬럼은 별도 DDL 로 drop
  - 심사 요청 시 NOT NULL 제약 위반으로 500 발생하던 문제 해결
- **CDN signed URL 한글 path 인코딩 (fix)**
  - `GcsService.generateCdnSignedUrl`: `objectPath` 를 `UriUtils.encodePath(..., UTF_8)` 로 percent-encode 후 서명
  - 이전엔 raw 한글 path 로 서명 → 클라이언트가 percent-encode 한 URL 로 요청 → CDN 서명 검증 실패 → 403
  - `/` 등 path separator 는 보존, 한글 등 non-ASCII 만 인코딩
- **GET /reviews/mine 추가 (feat)**
  - dashboard "심사 현황" 페이지가 호출하던 엔드포인트가 부재 → `/{id}` 패턴이 `mine` 을 path variable 로 잡아 UUID 변환 실패로 500
  - `ReviewRepository.findAllByPublisherMembership` (workspace member 기반 JPQL, FETCH JOIN 으로 N+1 방지)
  - `ReviewService.getMyReviews`
  - `ReviewController.GET /reviews/mine` — `hasRole('PUBLISHER' or 'ADMIN')`. `/{id}` 매핑보다 먼저 선언하여 path 충돌 방지

## DDL (live DB 적용 완료)

```sql
ALTER TABLE reviews DROP COLUMN review_id;
ALTER TABLE reviews DROP COLUMN created_at;  -- legacy, entity 는 submitted_at 사용
```

## Test plan

- [ ] 심사 요청 (`POST /reviews`) 201 응답 확인
- [ ] 한글 파일명 미니앱 번들 GET → 200 OK
- [ ] dashboard `/reviews` (심사 현황) 정상 노출
- [ ] `/reviews/{uuid}` (관리자) 회귀 없음