### PR TITLE
fix(review): reviewer 를 Publisher 로 매핑 + ClassCast 해결

### DIFF
--- a/src/main/java/com/union/union/domain/review/dto/ReviewResponseDto.java
+++ b/src/main/java/com/union/union/domain/review/dto/ReviewResponseDto.java
@@ -25,7 +25,7 @@ public record ReviewResponseDto(
             review.getVersion().getVersionNumber(),
             review.getVersion().getMiniApp().getName(),
             review.getVersion().getMiniApp().getWorkspace().getOwner().getName(),
-            review.getReviewer() != null ? review.getReviewer().getNickname() : null,
+            review.getReviewer() != null ? review.getReviewer().getName() : null,
             review.getVerdict(),
             review.getReason(),
             review.getCreatedAt(),

--- a/src/main/java/com/union/union/domain/review/entity/Review.java
+++ b/src/main/java/com/union/union/domain/review/entity/Review.java
@@ -1,7 +1,7 @@
 package com.union.union.domain.review.entity;
 
 import com.union.union.domain.appversion.entity.AppVersion;
-import com.union.union.domain.user.entity.User;
+import com.union.union.domain.publisher.entity.Publisher;
 import com.union.union.global.common.entity.BaseEntity;
 import com.union.union.global.common.exception.BadRequestException;
 import com.union.union.global.common.exception.ConflictException;
@@ -27,9 +27,10 @@ public class Review extends BaseEntity {
     @JoinColumn(name = "version_id", nullable = false)
     private AppVersion version;
 
+    /** 심사자(=관리자). 시스템상 admin 은 publishers 테이블에 role=ROLE_ADMIN 으로 존재. */
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "reviewer_id")
-    private User reviewer;
+    @JoinColumn(name = "reviewer_id", referencedColumnName = "publisher_id")
+    private Publisher reviewer;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
@@ -46,7 +47,7 @@ public class Review extends BaseEntity {
         this.verdict = Verdict.PENDING;
     }
 
-    public void decide(User reviewer, Verdict verdict, String reason) {
+    public void decide(Publisher reviewer, Verdict verdict, String reason) {
         if (this.verdict != Verdict.PENDING) {
             throw new ConflictException("이미 처리된 심사입니다");
         }

--- a/src/main/java/com/union/union/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/union/union/domain/review/repository/ReviewRepository.java
@@ -15,17 +15,35 @@ import java.util.UUID;
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, UUID> {
 
-    @EntityGraph(attributePaths = {"version", "version.miniApp", "version.miniApp.workspace", "reviewer"})
+    @EntityGraph(attributePaths = {
+            "version",
+            "version.miniApp",
+            "version.miniApp.workspace",
+            "version.miniApp.workspace.owner",
+            "reviewer"
+    })
     List<Review> findByVerdictOrderByCreatedAtAsc(Verdict verdict);
 
     Optional<Review> findByVersionId(UUID versionId);
 
-    @EntityGraph(attributePaths = {"version", "version.miniApp", "version.miniApp.workspace", "reviewer"})
+    @EntityGraph(attributePaths = {
+            "version",
+            "version.miniApp",
+            "version.miniApp.workspace",
+            "version.miniApp.workspace.owner",
+            "reviewer"
+    })
     Optional<Review> findDetailedByVersionIdAndVerdict(UUID versionId, Verdict verdict);
 
     boolean existsByVersionIdAndVerdict(UUID versionId, Verdict verdict);
 
-    @EntityGraph(attributePaths = {"version", "version.miniApp", "version.miniApp.workspace", "reviewer"})
+    @EntityGraph(attributePaths = {
+            "version",
+            "version.miniApp",
+            "version.miniApp.workspace",
+            "version.miniApp.workspace.owner",
+            "reviewer"
+    })
     Optional<Review> findDetailedById(UUID id);
 
     /**

--- a/src/main/java/com/union/union/domain/review/service/ReviewService.java
+++ b/src/main/java/com/union/union/domain/review/service/ReviewService.java
@@ -5,10 +5,10 @@ import com.union.union.domain.appversion.entity.AppVersion;
 import com.union.union.domain.appversion.entity.VersionStatus;
 import com.union.union.domain.appversion.repository.AppVersionRepository;
 import com.union.union.domain.appversion.service.AppVersionService;
+import com.union.union.domain.publisher.entity.Publisher;
+import com.union.union.domain.publisher.repository.PublisherRepository;
 import com.union.union.domain.review.dto.ReviewDecisionRequestDto;
 import com.union.union.domain.review.dto.ReviewResponseDto;
-import com.union.union.domain.user.entity.User;
-import com.union.union.domain.user.repository.UserRepository;
 import com.union.union.domain.review.entity.Review;
 import com.union.union.domain.review.entity.Verdict;
 import com.union.union.domain.review.repository.ReviewRepository;
@@ -36,7 +36,7 @@ public class ReviewService {
 
     private final ReviewRepository reviewRepository;
     private final AppVersionRepository appVersionRepository;
-    private final UserRepository userRepository;
+    private final PublisherRepository publisherRepository;
     private final WorkspaceAuthorizationService workspaceAuthorizationService;
     private final AppVersionService appVersionService;
 
@@ -101,7 +101,8 @@ public class ReviewService {
         Review review = reviewRepository.findDetailedById(reviewId)
                 .orElseThrow(() -> new EntityNotFoundException("Review를 찾을 수 없습니다"));
 
-        User admin = userRepository.findById(adminId).orElse(null);
+        Publisher admin = publisherRepository.findByPublisherId(adminId)
+                .orElseThrow(() -> new EntityNotFoundException("관리자를 찾을 수 없습니다"));
 
         review.decide(admin, request.verdict(), request.reason());
 
@@ -130,7 +131,8 @@ public class ReviewService {
             throw new BadRequestException("IN_REVIEW 상태가 아닙니다. 현재 상태: " + version.getStatus());
         }
 
-        User admin = userRepository.findById(adminId).orElse(null);
+        // admin 은 publishers 테이블에 role=ROLE_ADMIN 으로 존재. 누락 시에도 결정 진행(.orElse(null)).
+        Publisher admin = publisherRepository.findByPublisherId(adminId).orElse(null);
 
         Review review = reviewRepository.findDetailedByVersionIdAndVerdict(versionId, Verdict.PENDING)
                 .orElseGet(() -> {


### PR DESCRIPTION
## Summary

- **reviewer 를 User → Publisher 로 정정 (fix)**
  - dashboard 에서 admin 인증은 `publishers` 테이블(role=ROLE_ADMIN) 기준
  - 기존 코드가 `userRepository.findById(adminId)` 로 users 에서 admin 조회 → "관리자를 찾을 수 없습니다" 500 발생
  - `Review.reviewer` 타입 `User` → `Publisher` (referencedColumnName="publisher_id")
  - `ReviewService.decide` / `decideByVersionId` 모두 `publisherRepository.findByPublisherId` 로 통일
  - `ReviewResponseDto`: `getNickname()` → `getName()` (Publisher field)
- **Hibernate 6 ClassCast 해결 (fix)**
  - `@EntityGraph(attributePaths)` 에 EAGER 연관(`Workspace.owner`)이 빠지면 `EntityDelayedFetchInitializer` 로 감싸 시도 → `ClassCastException: Workspace cannot be cast to PersistentAttributeInterceptable`
  - `findDetailedById` / `findByVerdictOrderByCreatedAtAsc` / `findDetailedByVersionIdAndVerdict` 의 graph 에 `version.miniApp.workspace.owner` 명시

## DDL (live DB 적용 완료)

```sql
ALTER TABLE reviews DROP CONSTRAINT fkd1isgfajhtdl8mgg29up6mofi; -- legacy users FK
```

## Test plan

- [x] dashboard `POST /admin/reviews/{id}/approve` → backend `POST /reviews/{id}/decision` 200 (검증 완료)
- [ ] 반려 (REJECTED) 도 정상 동작
- [ ] dashboard 심사 현황 / 상세 페이지 회귀 없음