### PR TITLE
feat(deploy): MiniAppStatus DEPLOYED 추가 + Redis LocalDateTime 직렬화 수정

### DIFF
--- a/src/main/java/com/union/union/domain/analytics/service/AnalyticsIngestService.java
+++ b/src/main/java/com/union/union/domain/analytics/service/AnalyticsIngestService.java
@@ -144,10 +144,10 @@ public class AnalyticsIngestService {
         // 캐시 히트 → 검증 완료된 appId
         if (redisService.hasKey(cacheKey)) return;
 
-        boolean exists = miniAppRepository.existsByAppIdAndStatus(appId, MiniAppStatus.APPROVED);
+        boolean exists = miniAppRepository.existsByAppIdAndStatus(appId, MiniAppStatus.DEPLOYED);
         if (!exists) {
             throw new EntityNotFoundException(
-                "Mini-app not found or not approved: appId=" + appId
+                "Mini-app not found or not deployed: appId=" + appId
             );
         }
 

--- a/src/main/java/com/union/union/domain/appversion/dto/AppVersionResponseDto.java
+++ b/src/main/java/com/union/union/domain/appversion/dto/AppVersionResponseDto.java
@@ -2,6 +2,7 @@ package com.union.union.domain.appversion.dto;
 
 import com.union.union.domain.appversion.entity.AppVersion;
 import com.union.union.domain.appversion.entity.VersionStatus;
+import com.union.union.domain.miniapp.entity.MiniAppStatus;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -14,6 +15,7 @@ public record AppVersionResponseDto(
     String versionNumber,
     String releaseNotes,
     VersionStatus status,
+    MiniAppStatus miniAppStatus,
     String buildFileUrl,
     Long bundleSize,
     LocalDateTime testedAt,
@@ -29,6 +31,7 @@ public record AppVersionResponseDto(
             version.getVersionNumber(),
             version.getReleaseNotes(),
             version.getStatus(),
+            version.getMiniApp().getStatus(),
             version.getBuildFileUrl(),
             version.getBundleSize(),
             version.getTestedAt(),

--- a/src/main/java/com/union/union/domain/appversion/service/AppVersionService.java
+++ b/src/main/java/com/union/union/domain/appversion/service/AppVersionService.java
@@ -10,7 +10,6 @@ import com.union.union.domain.appversion.dto.TestLinkResponseDto;
 import com.union.union.domain.appversion.entity.AppVersion;
 import com.union.union.domain.appversion.repository.AppVersionRepository;
 import com.union.union.domain.miniapp.entity.MiniApp;
-import com.union.union.domain.miniapp.entity.MiniAppStatus;
 import com.union.union.domain.miniapp.repository.MiniAppRepository;
 import com.union.union.domain.workspace.service.WorkspaceAuthorizationService;
 import com.union.union.global.common.exception.BadRequestException;
@@ -58,7 +57,7 @@ public class AppVersionService {
 
         String token = UUID.randomUUID().toString();
         String redisKey = "test-link:" + token;
-        
+
         // 10분 유효기간 설정
         redisService.setValuesWithTimeout(redisKey, version.getId().toString(), Duration.ofMinutes(10));
 
@@ -92,8 +91,7 @@ public class AppVersionService {
                 version.getMiniApp().getId(),
                 version.getMiniApp().getName(),
                 version.getVersionNumber(),
-                signedUrl
-        );
+                signedUrl);
     }
 
     @Transactional
@@ -168,17 +166,14 @@ public class AppVersionService {
     @Transactional
     public AppVersionResponseDto deploy(UUID versionId, UUID publisherId) {
         AppVersion version = getVersionWithOwnerCheck(versionId, publisherId);
-        
+
         version.deploy();
-        
-        // Ensure parent MiniApp becomes AVAILABLE/APPROVED when its version goes live for the first time
+
         MiniApp miniApp = version.getMiniApp();
-        if (miniApp.getStatus() != MiniAppStatus.APPROVED) {
-            miniApp.approve();
-        }
+        miniApp.deploy();
 
         log.info("AppVersion 배포 완료 (DEPLOYED). versionId={}, miniAppId={}", versionId, miniApp.getId());
-        
+
         return AppVersionResponseDto.from(version);
     }
 
@@ -187,7 +182,8 @@ public class AppVersionService {
                 .orElseThrow(() -> new EntityNotFoundException("AppVersion을 찾을 수 없습니다"));
 
         if (!isAdmin()) {
-            workspaceAuthorizationService.validateMembership(version.getMiniApp().getWorkspace().getWorkspaceId(), publisherId);
+            workspaceAuthorizationService.validateMembership(version.getMiniApp().getWorkspace().getWorkspaceId(),
+                    publisherId);
         }
 
         return version;

--- a/src/main/java/com/union/union/domain/auth/controller/DevSeedController.java
+++ b/src/main/java/com/union/union/domain/auth/controller/DevSeedController.java
@@ -267,8 +267,8 @@ public class DevSeedController {
     private Map<String, Object> seedApp(Workspace workspace, MiniAppCategory category,
                                          String name, String description,
                                          String tags, String version) {
-        // 이미 동일 이름의 APPROVED 앱이 있으면 스킵
-        Optional<MiniApp> existing = miniAppRepository.findByStatus(MiniAppStatus.APPROVED)
+        // 이미 동일 이름의 DEPLOYED 앱이 있으면 스킵
+        Optional<MiniApp> existing = miniAppRepository.findByStatus(MiniAppStatus.DEPLOYED)
                 .stream()
                 .filter(a -> a.getName().equals(name) &&
                         a.getWorkspace().getWorkspaceId().equals(workspace.getWorkspaceId()))
@@ -290,7 +290,7 @@ public class DevSeedController {
                 .workspace(workspace)
                 .status(MiniAppStatus.PENDING)
                 .build());
-        app.approve();
+        app.deploy();
         miniAppRepository.save(app);
 
         // AppVersion: DRAFT → UPLOADED → tested → IN_REVIEW → ACCEPTED → DEPLOYED

--- a/src/main/java/com/union/union/domain/dev/service/DevSeedService.java
+++ b/src/main/java/com/union/union/domain/dev/service/DevSeedService.java
@@ -90,7 +90,7 @@ public class DevSeedService {
                                 .build()
                 ));
 
-        // 4. MiniApp 생성 (APPROVED)
+        // 4. MiniApp 생성 (DEPLOYED)
         MiniApp miniApp = MiniApp.builder()
                 .name(appName)
                 .description(description)
@@ -98,7 +98,7 @@ public class DevSeedService {
                 .category(category)
                 .tags(tags)
                 .workspace(workspace)
-                .status(MiniAppStatus.APPROVED)
+                .status(MiniAppStatus.DEPLOYED)
                 .build();
         miniApp.updateAppId(appId);
         miniApp = miniAppRepository.save(miniApp);

--- a/src/main/java/com/union/union/domain/miniapp/entity/MiniApp.java
+++ b/src/main/java/com/union/union/domain/miniapp/entity/MiniApp.java
@@ -79,6 +79,10 @@ public class MiniApp extends BaseEntity {
         this.status = MiniAppStatus.APPROVED;
     }
 
+    public void deploy() {
+        this.status = MiniAppStatus.DEPLOYED;
+    }
+
     public void reject() {
         this.status = MiniAppStatus.REJECTED;
     }

--- a/src/main/java/com/union/union/domain/miniapp/entity/MiniAppStatus.java
+++ b/src/main/java/com/union/union/domain/miniapp/entity/MiniAppStatus.java
@@ -3,5 +3,6 @@ package com.union.union.domain.miniapp.entity;
 public enum MiniAppStatus {
     PENDING,
     APPROVED,
-    REJECTED
+    REJECTED,
+    DEPLOYED
 }

--- a/src/main/java/com/union/union/domain/miniapp/repository/MiniAppRepository.java
+++ b/src/main/java/com/union/union/domain/miniapp/repository/MiniAppRepository.java
@@ -83,7 +83,7 @@ public interface MiniAppRepository extends JpaRepository<MiniApp, Long> {
     @Query("SELECT m FROM MiniApp m JOIN FETCH m.workspace WHERE m.category = :category AND m.status = :status")
     List<MiniApp> findByCategoryAndStatus(@Param("category") MiniAppCategory category, @Param("status") MiniAppStatus status, Pageable pageable);
 
-    @Query("SELECT m FROM MiniApp m JOIN FETCH m.workspace WHERE m.status = 'APPROVED' ORDER BY FUNCTION('RANDOM')")
+    @Query("SELECT m FROM MiniApp m JOIN FETCH m.workspace WHERE m.status = 'DEPLOYED' ORDER BY FUNCTION('RANDOM')")
     List<MiniApp> findRandomMiniApps(Pageable pageable);
 
     // ──────────────────────────────────────────────────────────────

--- a/src/main/java/com/union/union/domain/miniapp/service/MiniAppCacheService.java
+++ b/src/main/java/com/union/union/domain/miniapp/service/MiniAppCacheService.java
@@ -21,7 +21,7 @@ public class MiniAppCacheService {
 
     @Cacheable(value = "discovery_popular", sync = true)
     public List<MiniAppLiteDto> getPopularAppsCache() {
-        return miniAppRepository.findPopularMiniApps(MiniAppStatus.APPROVED, PageRequest.of(0, 10))
+        return miniAppRepository.findPopularMiniApps(MiniAppStatus.DEPLOYED, PageRequest.of(0, 10))
                 .stream()
                 .map(MiniAppLiteDto::from)
                 .collect(Collectors.toList());
@@ -29,7 +29,7 @@ public class MiniAppCacheService {
 
     @Cacheable(value = "discovery_new", sync = true)
     public List<MiniAppLiteDto> getNewAppsCache() {
-        return miniAppRepository.findNewMiniApps(MiniAppStatus.APPROVED, PageRequest.of(0, 10))
+        return miniAppRepository.findNewMiniApps(MiniAppStatus.DEPLOYED, PageRequest.of(0, 10))
                 .stream()
                 .map(MiniAppLiteDto::from)
                 .collect(Collectors.toList());

--- a/src/main/java/com/union/union/domain/miniapp/service/MiniAppSearchService.java
+++ b/src/main/java/com/union/union/domain/miniapp/service/MiniAppSearchService.java
@@ -34,7 +34,7 @@ public class MiniAppSearchService {
             redisService.incrementScore(SEARCH_TRENDING_KEY, keyword.trim(), 1.0);
         }
 
-        return miniAppRepository.searchByKeyword(keyword, MiniAppStatus.APPROVED, pageable)
+        return miniAppRepository.searchByKeyword(keyword, MiniAppStatus.DEPLOYED, pageable)
                 .stream()
                 .map(MiniAppLiteDto::from)
                 .collect(Collectors.toList());
@@ -47,7 +47,7 @@ public class MiniAppSearchService {
 
         String jamoPrefix = com.union.union.domain.miniapp.utils.KoreanUtils.decompose(keyword.trim().toLowerCase());
 
-        return miniAppRepository.findByStatusAndSearchableNameStartingWith(MiniAppStatus.APPROVED, jamoPrefix, pageable)
+        return miniAppRepository.findByStatusAndSearchableNameStartingWith(MiniAppStatus.DEPLOYED, jamoPrefix, pageable)
                 .stream()
                 .map(MiniAppLiteDto::from)
                 .collect(Collectors.toList());
@@ -57,7 +57,7 @@ public class MiniAppSearchService {
         MiniAppCategory category = miniAppCategoryRepository.findById(categoryId)
                 .orElseThrow(() -> new com.union.union.global.common.exception.EntityNotFoundException("카테고리를 찾을 수 없습니다"));
 
-        return miniAppRepository.findByCategoryAndStatus(category, MiniAppStatus.APPROVED, pageable)
+        return miniAppRepository.findByCategoryAndStatus(category, MiniAppStatus.DEPLOYED, pageable)
                 .stream()
                 .map(MiniAppLiteDto::from)
                 .collect(Collectors.toList());

--- a/src/main/java/com/union/union/domain/miniapp/service/MiniAppService.java
+++ b/src/main/java/com/union/union/domain/miniapp/service/MiniAppService.java
@@ -81,7 +81,7 @@ public class MiniAppService {
     // TODO: 커서 페이징 구현 (기획 확정 후)
     @Cacheable(value = "miniApps", key = "'approved'")
     public List<MiniAppResponseDto> getApprovedMiniApps() {
-        return miniAppRepository.findByStatus(MiniAppStatus.APPROVED)
+        return miniAppRepository.findByStatus(MiniAppStatus.DEPLOYED)
                 .stream()
                 .map(MiniAppResponseDto::from)
                 .collect(Collectors.toList());
@@ -89,7 +89,7 @@ public class MiniAppService {
 
     @Cacheable(value = "popularMiniApps", key = "#limit")
     public List<MiniAppResponseDto> getPopularMiniApps(int limit) {
-        return miniAppRepository.findPopularMiniApps(MiniAppStatus.APPROVED, PageRequest.of(0, limit))
+        return miniAppRepository.findPopularMiniApps(MiniAppStatus.DEPLOYED, PageRequest.of(0, limit))
                 .stream()
                 .map(MiniAppResponseDto::from)
                 .collect(Collectors.toList());
@@ -101,10 +101,10 @@ public class MiniAppService {
 
         // 1. 같은 대학 인기 앱 (Top 5)
         List<MiniApp> universityPopular = miniAppRepository.findRecommendedByUniversity(
-                user.getUniversityName(), MiniAppStatus.APPROVED, PageRequest.of(0, 5));
+                user.getUniversityName(), MiniAppStatus.DEPLOYED, PageRequest.of(0, 5));
 
         // 2. 내가 최근에 사용한 앱 (Top 5)
-        List<MiniApp> myRecent = miniAppRepository.findRecentByUser(userId, MiniAppStatus.APPROVED, PageRequest.of(0, 5));
+        List<MiniApp> myRecent = miniAppRepository.findRecentByUser(userId, MiniAppStatus.DEPLOYED, PageRequest.of(0, 5));
 
         // 3. ID 기반 중복 제거 및 결합
         java.util.LinkedHashMap<Long, MiniApp> combined = new java.util.LinkedHashMap<>();
@@ -113,7 +113,7 @@ public class MiniAppService {
 
         // 4. 결과가 부족하면 글로벌 인기 앱 추가
         if (combined.size() < 5) {
-            List<MiniApp> globalPopular = miniAppRepository.findPopularMiniApps(MiniAppStatus.APPROVED, PageRequest.of(0, 10));
+            List<MiniApp> globalPopular = miniAppRepository.findPopularMiniApps(MiniAppStatus.DEPLOYED, PageRequest.of(0, 10));
             for (MiniApp popular : globalPopular) {
                 combined.putIfAbsent(popular.getId(), popular);
                 if (combined.size() >= 10) break;
@@ -159,7 +159,7 @@ public class MiniAppService {
         if (userId == null) {
             return java.util.Collections.emptyList();
         }
-        return miniAppRepository.findRecentByUser(userId, MiniAppStatus.APPROVED, PageRequest.of(0, 5))
+        return miniAppRepository.findRecentByUser(userId, MiniAppStatus.DEPLOYED, PageRequest.of(0, 5))
                 .stream()
                 .map(MiniAppLiteDto::from)
                 .collect(Collectors.toList());
@@ -197,8 +197,8 @@ public class MiniAppService {
         MiniApp miniApp = miniAppRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("MiniApp을 찾을 수 없습니다"));
 
-        if (miniApp.getStatus() != MiniAppStatus.APPROVED) {
-            throw new UnauthorizedAccessException("승인되지 않은 MiniApp입니다");
+        if (miniApp.getStatus() != MiniAppStatus.DEPLOYED) {
+            throw new UnauthorizedAccessException("배포되지 않은 MiniApp입니다");
         }
 
         // TODO: 대학교 제한 체크 (university 필터링 확정 후 구현)

--- a/src/main/java/com/union/union/global/config/RedisConfig.java
+++ b/src/main/java/com/union/union/global/config/RedisConfig.java
@@ -1,5 +1,8 @@
 package com.union.union.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
@@ -51,11 +54,21 @@ public class RedisConfig {
 
     @Bean
     public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        ObjectMapper cacheObjectMapper = new ObjectMapper();
+        cacheObjectMapper.registerModule(new JavaTimeModule());
+        cacheObjectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        cacheObjectMapper.activateDefaultTyping(
+                cacheObjectMapper.getPolymorphicTypeValidator(),
+                ObjectMapper.DefaultTyping.NON_FINAL
+        );
+
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(cacheObjectMapper);
+
         RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
                 .entryTtl(Duration.ofMinutes(5))
                 .disableCachingNullValues()
                 .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()));
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer));
 
         // 캐시별 TTL 개별 설정
         Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();


### PR DESCRIPTION
- MiniAppStatus에 DEPLOYED 추가, deploy() 시 MiniApp.status를 DEPLOYED로 변경
- AppVersionResponseDto에 miniAppStatus 필드 추가 (프론트 전달용)
- 앱 탐색/검색/캐시/애널리틱스 전반의 'APPROVED' 라이브 필터를 'DEPLOYED'로 교체
- RedisConfig CacheManager에 JavaTimeModule 등록하여 LocalDateTime 직렬화 500 오류 수정