### PR TITLE
feat(notification): FCM 푸쉬 알림 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 	// Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	// Firebase Admin SDK (FCM push notifications)
+	implementation 'com.google.firebase:firebase-admin:9.3.0'
+
 	runtimeOnly 'org.postgresql:postgresql'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/union/union/domain/appversion/service/AppVersionService.java
+++ b/src/main/java/com/union/union/domain/appversion/service/AppVersionService.java
@@ -11,6 +11,7 @@ import com.union.union.domain.appversion.entity.AppVersion;
 import com.union.union.domain.appversion.repository.AppVersionRepository;
 import com.union.union.domain.miniapp.entity.MiniApp;
 import com.union.union.domain.miniapp.repository.MiniAppRepository;
+import com.union.union.domain.notification.service.NotificationService;
 import com.union.union.domain.workspace.service.WorkspaceAuthorizationService;
 import com.union.union.global.common.exception.BadRequestException;
 import com.union.union.global.common.exception.ConflictException;
@@ -41,6 +42,7 @@ public class AppVersionService {
     private final GcsService gcsService;
     private final RedisService redisService;
     private final Storage storage;
+    private final NotificationService notificationService;
 
     @Value("${spring.cloud.gcp.storage.bucket}")
     private String bucketName;
@@ -173,6 +175,10 @@ public class AppVersionService {
         miniApp.deploy();
 
         log.info("AppVersion 배포 완료 (DEPLOYED). versionId={}, miniAppId={}", versionId, miniApp.getId());
+        notificationService.sendToPublisher(
+                miniApp.getWorkspace().getOwner().getPublisherId(),
+                "배포 완료",
+                miniApp.getName() + " " + version.getVersionNumber() + " 버전이 배포되었습니다.");
 
         return AppVersionResponseDto.from(version);
     }

--- a/src/main/java/com/union/union/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/union/union/domain/notification/controller/NotificationController.java
@@ -1,0 +1,39 @@
+package com.union.union.domain.notification.controller;
+
+import com.union.union.domain.notification.dto.FcmTokenRequestDto;
+import com.union.union.domain.notification.service.NotificationService;
+import com.union.union.global.security.jwt.JwtUserPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @PostMapping("/token")
+    public ResponseEntity<Void> registerToken(
+            @Valid @RequestBody FcmTokenRequestDto request,
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        if (principal.role().contains("PUBLISHER") || principal.role().contains("ADMIN")) {
+            notificationService.registerPublisherToken(principal.userId(), request.token());
+        } else {
+            notificationService.registerUserToken(principal.userId(), request.token());
+        }
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/token")
+    public ResponseEntity<Void> deleteToken(
+            @Valid @RequestBody FcmTokenRequestDto request
+    ) {
+        notificationService.deleteToken(request.token());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/union/union/domain/notification/dto/FcmTokenRequestDto.java
+++ b/src/main/java/com/union/union/domain/notification/dto/FcmTokenRequestDto.java
@@ -1,0 +1,7 @@
+package com.union.union.domain.notification.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record FcmTokenRequestDto(
+        @NotBlank String token
+) {}

--- a/src/main/java/com/union/union/domain/notification/entity/PublisherFcmToken.java
+++ b/src/main/java/com/union/union/domain/notification/entity/PublisherFcmToken.java
@@ -1,0 +1,30 @@
+package com.union.union.domain.notification.entity;
+
+import com.union.union.domain.publisher.entity.Publisher;
+import com.union.union.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "publisher_fcm_tokens")
+public class PublisherFcmToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "publisher_id", referencedColumnName = "publisher_id", nullable = false)
+    private Publisher publisher;
+
+    @Column(nullable = false, unique = true, length = 500)
+    private String token;
+
+    @Builder
+    public PublisherFcmToken(Publisher publisher, String token) {
+        this.publisher = publisher;
+        this.token = token;
+    }
+}

--- a/src/main/java/com/union/union/domain/notification/entity/UserFcmToken.java
+++ b/src/main/java/com/union/union/domain/notification/entity/UserFcmToken.java
@@ -1,0 +1,30 @@
+package com.union.union.domain.notification.entity;
+
+import com.union.union.domain.user.entity.User;
+import com.union.union.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_fcm_tokens")
+public class UserFcmToken extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, unique = true, length = 500)
+    private String token;
+
+    @Builder
+    public UserFcmToken(User user, String token) {
+        this.user = user;
+        this.token = token;
+    }
+}

--- a/src/main/java/com/union/union/domain/notification/repository/PublisherFcmTokenRepository.java
+++ b/src/main/java/com/union/union/domain/notification/repository/PublisherFcmTokenRepository.java
@@ -1,0 +1,22 @@
+package com.union.union.domain.notification.repository;
+
+import com.union.union.domain.notification.entity.PublisherFcmToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface PublisherFcmTokenRepository extends JpaRepository<PublisherFcmToken, Long> {
+
+    @Query("SELECT t.token FROM PublisherFcmToken t WHERE t.publisher.publisherId = :publisherId")
+    List<String> findTokensByPublisherId(@Param("publisherId") UUID publisherId);
+
+    Optional<PublisherFcmToken> findByToken(String token);
+
+    void deleteByToken(String token);
+}

--- a/src/main/java/com/union/union/domain/notification/repository/UserFcmTokenRepository.java
+++ b/src/main/java/com/union/union/domain/notification/repository/UserFcmTokenRepository.java
@@ -1,0 +1,22 @@
+package com.union.union.domain.notification.repository;
+
+import com.union.union.domain.notification.entity.UserFcmToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface UserFcmTokenRepository extends JpaRepository<UserFcmToken, Long> {
+
+    @Query("SELECT t.token FROM UserFcmToken t WHERE t.user.id = :userId")
+    List<String> findTokensByUserId(@Param("userId") UUID userId);
+
+    Optional<UserFcmToken> findByToken(String token);
+
+    void deleteByToken(String token);
+}

--- a/src/main/java/com/union/union/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/union/union/domain/notification/service/NotificationService.java
@@ -1,0 +1,75 @@
+package com.union.union.domain.notification.service;
+
+import com.union.union.domain.notification.entity.PublisherFcmToken;
+import com.union.union.domain.notification.entity.UserFcmToken;
+import com.union.union.domain.notification.repository.PublisherFcmTokenRepository;
+import com.union.union.domain.notification.repository.UserFcmTokenRepository;
+import com.union.union.domain.publisher.entity.Publisher;
+import com.union.union.domain.publisher.repository.PublisherRepository;
+import com.union.union.domain.user.entity.User;
+import com.union.union.domain.user.repository.UserRepository;
+import com.union.union.global.common.exception.EntityNotFoundException;
+import com.union.union.global.infra.fcm.FcmService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationService {
+
+    private final PublisherFcmTokenRepository publisherFcmTokenRepository;
+    private final UserFcmTokenRepository userFcmTokenRepository;
+    private final PublisherRepository publisherRepository;
+    private final UserRepository userRepository;
+    private final FcmService fcmService;
+
+    public void registerPublisherToken(UUID publisherId, String token) {
+        if (publisherFcmTokenRepository.findByToken(token).isPresent()) {
+            return;
+        }
+        Publisher publisher = publisherRepository.findByPublisherId(publisherId)
+                .orElseThrow(() -> new EntityNotFoundException("Publisher를 찾을 수 없습니다"));
+        publisherFcmTokenRepository.save(PublisherFcmToken.builder()
+                .publisher(publisher)
+                .token(token)
+                .build());
+        log.info("Publisher FCM 토큰 등록. publisherId={}", publisherId);
+    }
+
+    public void registerUserToken(UUID userId, String token) {
+        if (userFcmTokenRepository.findByToken(token).isPresent()) {
+            return;
+        }
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("User를 찾을 수 없습니다"));
+        userFcmTokenRepository.save(UserFcmToken.builder()
+                .user(user)
+                .token(token)
+                .build());
+        log.info("User FCM 토큰 등록. userId={}", userId);
+    }
+
+    public void deleteToken(String token) {
+        publisherFcmTokenRepository.deleteByToken(token);
+        userFcmTokenRepository.deleteByToken(token);
+    }
+
+    @Transactional(readOnly = true)
+    public void sendToPublisher(UUID publisherId, String title, String body) {
+        List<String> tokens = publisherFcmTokenRepository.findTokensByPublisherId(publisherId);
+        fcmService.sendMulticast(tokens, title, body);
+    }
+
+    @Transactional(readOnly = true)
+    public void sendToUser(UUID userId, String title, String body) {
+        List<String> tokens = userFcmTokenRepository.findTokensByUserId(userId);
+        fcmService.sendMulticast(tokens, title, body);
+    }
+}

--- a/src/main/java/com/union/union/domain/review/service/ReviewService.java
+++ b/src/main/java/com/union/union/domain/review/service/ReviewService.java
@@ -12,6 +12,7 @@ import com.union.union.domain.review.dto.ReviewResponseDto;
 import com.union.union.domain.review.entity.Review;
 import com.union.union.domain.review.entity.Verdict;
 import com.union.union.domain.review.repository.ReviewRepository;
+import com.union.union.domain.notification.service.NotificationService;
 import com.union.union.domain.workspace.service.WorkspaceAuthorizationService;
 import com.union.union.global.common.exception.BadRequestException;
 import com.union.union.global.common.exception.ConflictException;
@@ -39,6 +40,7 @@ public class ReviewService {
     private final PublisherRepository publisherRepository;
     private final WorkspaceAuthorizationService workspaceAuthorizationService;
     private final AppVersionService appVersionService;
+    private final NotificationService notificationService;
 
     @Transactional
     public ReviewResponseDto submitForReview(UUID versionId, UUID publisherId) {
@@ -107,12 +109,17 @@ public class ReviewService {
         review.decide(admin, request.verdict(), request.reason());
 
         AppVersion version = review.getVersion();
+        UUID publisherId = version.getMiniApp().getWorkspace().getOwner().getPublisherId();
         if (request.verdict() == Verdict.ACCEPTED) {
             version.accept();
             log.info("심사 승인. reviewId={}, versionId={}", reviewId, version.getId());
+            notificationService.sendToPublisher(publisherId, "심사 승인",
+                    version.getMiniApp().getName() + " 앱이 심사를 통과했습니다. 배포 버튼을 눌러 출시하세요.");
         } else {
             version.reject();
             log.info("심사 거절. reviewId={}, versionId={}, reason={}", reviewId, version.getId(), request.reason());
+            notificationService.sendToPublisher(publisherId, "심사 거절",
+                    version.getMiniApp().getName() + " 앱이 심사에서 거절되었습니다. 사유: " + request.reason());
         }
 
         return ReviewResponseDto.from(review);
@@ -142,12 +149,17 @@ public class ReviewService {
 
         review.decide(admin, request.verdict(), request.reason());
 
+        UUID publisherId = version.getMiniApp().getWorkspace().getOwner().getPublisherId();
         if (request.verdict() == Verdict.ACCEPTED) {
             version.accept();
             log.info("심사 승인 (versionId 기준). versionId={}", versionId);
+            notificationService.sendToPublisher(publisherId, "심사 승인",
+                    version.getMiniApp().getName() + " 앱이 심사를 통과했습니다. 배포 버튼을 눌러 출시하세요.");
         } else {
             version.reject();
             log.info("심사 거절 (versionId 기준). versionId={}, reason={}", versionId, request.reason());
+            notificationService.sendToPublisher(publisherId, "심사 거절",
+                    version.getMiniApp().getName() + " 앱이 심사에서 거절되었습니다. 사유: " + request.reason());
         }
 
         return ReviewResponseDto.from(review);

--- a/src/main/java/com/union/union/global/config/FirebaseConfig.java
+++ b/src/main/java/com/union/union/global/config/FirebaseConfig.java
@@ -1,0 +1,40 @@
+package com.union.union.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+@Slf4j
+@Configuration
+public class FirebaseConfig {
+
+    @Value("${firebase.credential-path:}")
+    private String credentialPath;
+
+    @PostConstruct
+    public void init() {
+        if (credentialPath.isBlank()) {
+            log.warn("firebase.credential-path 미설정 — 푸쉬 알림 비활성화 상태로 기동");
+            return;
+        }
+        if (!FirebaseApp.getApps().isEmpty()) {
+            return;
+        }
+        try (FileInputStream serviceAccount = new FileInputStream(credentialPath)) {
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+            FirebaseApp.initializeApp(options);
+            log.info("Firebase 초기화 완료. credential={}", credentialPath);
+        } catch (IOException e) {
+            log.error("Firebase 초기화 실패 — 푸쉬 알림 비활성화: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/union/union/global/infra/fcm/FcmService.java
+++ b/src/main/java/com/union/union/global/infra/fcm/FcmService.java
@@ -1,0 +1,40 @@
+package com.union.union.global.infra.fcm;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.Notification;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Slf4j
+@Service
+public class FcmService {
+
+    public void sendMulticast(List<String> tokens, String title, String body) {
+        if (tokens.isEmpty()) {
+            return;
+        }
+        if (FirebaseApp.getApps().isEmpty()) {
+            log.debug("Firebase 미초기화 — 알림 스킵. title={}", title);
+            return;
+        }
+        try {
+            MulticastMessage message = MulticastMessage.builder()
+                    .setNotification(Notification.builder()
+                            .setTitle(title)
+                            .setBody(body)
+                            .build())
+                    .addAllTokens(tokens)
+                    .build();
+            var response = FirebaseMessaging.getInstance().sendEachForMulticast(message);
+            log.info("FCM 발송 완료. success={}, failure={}, title={}",
+                    response.getSuccessCount(), response.getFailureCount(), title);
+        } catch (FirebaseMessagingException e) {
+            log.error("FCM 발송 실패: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/union/union/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/union/union/global/security/config/SecurityConfig.java
@@ -87,6 +87,9 @@ public class SecurityConfig {
                 // Admin endpoints
                 .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
 
+                // Notification (FCM token 등록/삭제)
+                .requestMatchers("/notifications/token").authenticated()
+
                 // All other endpoints require authentication
                 .anyRequest().authenticated()
             )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -95,3 +95,6 @@ token-cleanup:
 
 universal-link:
   base-url: ${UNIVERSAL_LINK_BASE_URL:union-app://test-app}
+
+firebase:
+  credential-path: ${FIREBASE_CREDENTIAL_PATH:}


### PR DESCRIPTION
- firebase-admin SDK 추가, 키 미설정 시 graceful skip으로 기동
- PublisherFcmToken / UserFcmToken 엔티티 및 레포지토리 추가
- POST /notifications/token, DELETE /notifications/token API 추가
- 심사 승인/거절, 배포 완료 시 Publisher에게 알림 발송
- MiniAppStatus DEPLOYED 추가, 라이브 앱 필터 APPROVED → DEPLOYED 전환