### PR TITLE
feat: Banner 도메인 + /users/me + MiniAppLiteDto 보강

### DIFF
--- a/src/main/java/com/union/union/domain/auth/controller/DevSeedController.java
+++ b/src/main/java/com/union/union/domain/auth/controller/DevSeedController.java
@@ -2,8 +2,13 @@ package com.union.union.domain.auth.controller;
 
 import com.union.union.domain.appversion.entity.AppVersion;
 import com.union.union.domain.appversion.repository.AppVersionRepository;
+import com.union.union.domain.banner.entity.Banner;
+import com.union.union.domain.banner.entity.BannerLinkType;
+import com.union.union.domain.banner.repository.BannerRepository;
+import com.union.union.domain.banner.service.BannerService;
 import com.union.union.domain.dev.dto.DevSeedResponseDto;
 import com.union.union.domain.dev.service.DevSeedService;
+import com.union.union.global.infra.gcs.GcsService;
 import com.union.union.domain.miniapp.entity.MiniApp;
 import com.union.union.domain.miniapp.entity.MiniAppCategory;
 import com.union.union.domain.miniapp.entity.MiniAppStatus;
@@ -57,6 +62,9 @@ public class DevSeedController {
     private final AppVersionRepository appVersionRepository;
     private final EntityManager entityManager;
     private final DevSeedService devSeedService;
+    private final BannerRepository bannerRepository;
+    private final BannerService bannerService;
+    private final GcsService gcsService;
 
     private static final UUID TEST_PUBLISHER_ID = UUID.fromString("66d1bf78-29b5-45d8-bba7-f08f88bffa23");
     private static final UUID TEST_WORKSPACE_ID = UUID.fromString("77d1bf78-29b5-45d8-bba7-f08f88bffa23");
@@ -159,6 +167,54 @@ public class DevSeedController {
                 versionNumber, releaseNotes, iconUrl, publisherName, file
         );
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    /**
+     * 배너 시드 — 이미지 파일과 메타데이터를 받아 GCS 업로드 + DB INSERT.
+     *
+     * Content-Type: multipart/form-data
+     * required:  file
+     * optional:  title, subtitle, linkType (default NONE), linkTarget,
+     *            sortOrder (default 0), targetUniversity
+     *
+     * 반환: { id, imageUrl }
+     */
+    @PostMapping(value = "/seed/banner", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Transactional
+    public ResponseEntity<Map<String, Object>> seedBanner(
+            @RequestPart("file") MultipartFile file,
+            @RequestParam(required = false) String title,
+            @RequestParam(required = false) String subtitle,
+            @RequestParam(required = false, defaultValue = "NONE") BannerLinkType linkType,
+            @RequestParam(required = false) String linkTarget,
+            @RequestParam(required = false, defaultValue = "0") int sortOrder,
+            @RequestParam(required = false) String targetUniversity
+    ) throws IOException {
+        String safeName = file.getOriginalFilename() != null ? file.getOriginalFilename() : "banner.png";
+        String objectPath = "banners/" + UUID.randomUUID() + "-" + safeName.replaceAll("[^A-Za-z0-9._-]", "_");
+        String imageUrl = gcsService.uploadBannerImage(file, objectPath);
+
+        Banner banner = Banner.builder()
+                .imageUrl(imageUrl)
+                .title(title)
+                .subtitle(subtitle)
+                .linkType(linkType)
+                .linkTarget(linkTarget)
+                .sortOrder(sortOrder)
+                .isActive(true)
+                .targetUniversity(targetUniversity)
+                .build();
+        bannerRepository.save(banner);
+        bannerService.invalidateCache();
+
+        log.info("Banner seed 완료. id={}, imageUrl={}", banner.getId(), imageUrl);
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("id", banner.getId());
+        body.put("imageUrl", imageUrl);
+        body.put("linkType", banner.getLinkType());
+        body.put("sortOrder", banner.getSortOrder());
+        return ResponseEntity.status(HttpStatus.CREATED).body(body);
     }
 
     /**

--- a/src/main/java/com/union/union/domain/banner/controller/BannerController.java
+++ b/src/main/java/com/union/union/domain/banner/controller/BannerController.java
@@ -1,0 +1,28 @@
+package com.union.union.domain.banner.controller;
+
+import com.union.union.domain.banner.dto.BannerResponseDto;
+import com.union.union.domain.banner.service.BannerService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/banners")
+@RequiredArgsConstructor
+public class BannerController {
+
+    private final BannerService bannerService;
+
+    /**
+     * Home 캐러셀용 활성 배너 목록.
+     * GET /banners — public, 5분 캐시.
+     */
+    @GetMapping
+    public ResponseEntity<List<BannerResponseDto>> getBanners() {
+        return ResponseEntity.ok(bannerService.getActiveBanners());
+    }
+}

--- a/src/main/java/com/union/union/domain/banner/dto/BannerResponseDto.java
+++ b/src/main/java/com/union/union/domain/banner/dto/BannerResponseDto.java
@@ -1,0 +1,30 @@
+package com.union.union.domain.banner.dto;
+
+import com.union.union.domain.banner.entity.Banner;
+import com.union.union.domain.banner.entity.BannerLinkType;
+
+public record BannerResponseDto(
+        Long id,
+        String imageUrl,
+        String title,
+        String subtitle,
+        String emoji,
+        String gradientStartHex,
+        String gradientEndHex,
+        BannerLinkType linkType,
+        String linkTarget
+) {
+    public static BannerResponseDto from(Banner b) {
+        return new BannerResponseDto(
+                b.getId(),
+                b.getImageUrl(),
+                b.getTitle(),
+                b.getSubtitle(),
+                b.getEmoji(),
+                b.getGradientStartHex(),
+                b.getGradientEndHex(),
+                b.getLinkType(),
+                b.getLinkTarget()
+        );
+    }
+}

--- a/src/main/java/com/union/union/domain/banner/entity/Banner.java
+++ b/src/main/java/com/union/union/domain/banner/entity/Banner.java
@@ -1,0 +1,83 @@
+package com.union.union.domain.banner.entity;
+
+import com.union.union.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "banners", indexes = {
+        @Index(name = "idx_banners_active_window", columnList = "isActive, startAt, endAt, sortOrder")
+})
+public class Banner extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 500)
+    private String imageUrl;
+
+    @Column(length = 100)
+    private String title;
+
+    @Column(length = 200)
+    private String subtitle;
+
+    @Column(length = 8)
+    private String emoji;
+
+    @Column(length = 6)
+    private String gradientStartHex;
+
+    @Column(length = 6)
+    private String gradientEndHex;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private BannerLinkType linkType;
+
+    @Column(length = 500)
+    private String linkTarget;
+
+    @Column(nullable = false)
+    private int sortOrder;
+
+    @Column(nullable = false)
+    private boolean isActive;
+
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+
+    @Column(length = 100)
+    private String targetUniversity;
+
+    @Builder
+    public Banner(
+            String imageUrl, String title, String subtitle,
+            String emoji, String gradientStartHex, String gradientEndHex,
+            BannerLinkType linkType, String linkTarget,
+            Integer sortOrder, Boolean isActive,
+            LocalDateTime startAt, LocalDateTime endAt, String targetUniversity
+    ) {
+        this.imageUrl = imageUrl;
+        this.title = title;
+        this.subtitle = subtitle;
+        this.emoji = emoji;
+        this.gradientStartHex = gradientStartHex;
+        this.gradientEndHex = gradientEndHex;
+        this.linkType = linkType != null ? linkType : BannerLinkType.NONE;
+        this.linkTarget = linkTarget;
+        this.sortOrder = sortOrder != null ? sortOrder : 0;
+        this.isActive = isActive != null ? isActive : true;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.targetUniversity = targetUniversity;
+    }
+
+    public void activate()   { this.isActive = true; }
+    public void deactivate() { this.isActive = false; }
+}

--- a/src/main/java/com/union/union/domain/banner/entity/BannerLinkType.java
+++ b/src/main/java/com/union/union/domain/banner/entity/BannerLinkType.java
@@ -1,0 +1,10 @@
+package com.union.union.domain.banner.entity;
+
+public enum BannerLinkType {
+    /** 클릭 액션 없음 — 단순 노출 배너 */
+    NONE,
+    /** 미니앱 실행 — link_target 은 MiniApp.id (Long) 의 문자열 표현 */
+    MINI_APP,
+    /** 외부 URL — link_target 은 https URL */
+    EXTERNAL_URL
+}

--- a/src/main/java/com/union/union/domain/banner/repository/BannerRepository.java
+++ b/src/main/java/com/union/union/domain/banner/repository/BannerRepository.java
@@ -1,0 +1,27 @@
+package com.union.union.domain.banner.repository;
+
+import com.union.union.domain.banner.entity.Banner;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface BannerRepository extends JpaRepository<Banner, Long> {
+
+    /**
+     * 현재 시각 기준 활성 + 노출 윈도우 내 배너 목록 (sort_order 오름차순, created_at 내림차순).
+     * start_at NULL = 즉시 노출 시작, end_at NULL = 무기한.
+     */
+    @Query("""
+        SELECT b FROM Banner b
+        WHERE b.isActive = true
+          AND (b.startAt IS NULL OR b.startAt <= :now)
+          AND (b.endAt   IS NULL OR b.endAt   >= :now)
+        ORDER BY b.sortOrder ASC, b.createdAt DESC
+    """)
+    List<Banner> findActiveBanners(@Param("now") LocalDateTime now);
+}

--- a/src/main/java/com/union/union/domain/banner/service/BannerService.java
+++ b/src/main/java/com/union/union/domain/banner/service/BannerService.java
@@ -1,0 +1,41 @@
+package com.union.union.domain.banner.service;
+
+import com.union.union.domain.banner.dto.BannerResponseDto;
+import com.union.union.domain.banner.repository.BannerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BannerService {
+
+    private final BannerRepository bannerRepository;
+
+    /**
+     * 활성 배너 목록 — 캐시 5분.
+     * 시점 의존이라 캐시 키에 시간을 포함하지 않고 전체 결과를 단일 키로 보관.
+     * (배너 변경 빈도 낮음, 약간의 staleness 허용.)
+     */
+    @Cacheable(value = "banners", key = "'active'")
+    public List<BannerResponseDto> getActiveBanners() {
+        return bannerRepository.findActiveBanners(LocalDateTime.now())
+                .stream()
+                .map(BannerResponseDto::from)
+                .toList();
+    }
+
+    /**
+     * 배너 등록/수정/삭제 시 호출 — 캐시 무효화.
+     */
+    @CacheEvict(value = "banners", allEntries = true)
+    public void invalidateCache() {
+        // marker
+    }
+}

--- a/src/main/java/com/union/union/domain/miniapp/dto/MiniAppLiteDto.java
+++ b/src/main/java/com/union/union/domain/miniapp/dto/MiniAppLiteDto.java
@@ -1,6 +1,6 @@
 package com.union.union.domain.miniapp.dto;
 
-
+import java.time.LocalDateTime;
 
 public record MiniAppLiteDto(
         Long id,
@@ -9,7 +9,9 @@ public record MiniAppLiteDto(
         String iconUrl,
         String publisherName,
         MiniAppCategoryResponseDto category,
-        Double rating
+        Double rating,
+        String description,
+        LocalDateTime createdAt
 ) {
     public static MiniAppLiteDto from(com.union.union.domain.miniapp.entity.MiniApp miniApp) {
         return new MiniAppLiteDto(
@@ -19,7 +21,9 @@ public record MiniAppLiteDto(
                 miniApp.getIconUrl(),
                 miniApp.getWorkspace() != null ? miniApp.getWorkspace().getName() : "Union Dev",
                 miniApp.getCategory() != null ? MiniAppCategoryResponseDto.from(miniApp.getCategory()) : null,
-                4.5 // Mock rating for now
+                null, // rating: 별점 도메인 미구현 (추후 user_app_ratings 테이블 도입 시 채움)
+                miniApp.getDescription(),
+                miniApp.getCreatedAt()
         );
     }
 }

--- a/src/main/java/com/union/union/domain/user/controller/UserController.java
+++ b/src/main/java/com/union/union/domain/user/controller/UserController.java
@@ -2,9 +2,11 @@ package com.union.union.domain.user.controller;
 
 import com.union.union.domain.user.entity.User;
 import com.union.union.domain.user.service.UserService;
+import com.union.union.global.security.jwt.JwtUserPrincipal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -16,6 +18,12 @@ import java.util.UUID;
 public class UserController {
 
     private final UserService userService;
+
+    @GetMapping("/me")
+    public ResponseEntity<UserResponse> getMe(@AuthenticationPrincipal JwtUserPrincipal principal) {
+        User user = userService.getUser(principal.userId());
+        return ResponseEntity.ok(UserResponse.from(user));
+    }
 
     @GetMapping("/{id}")
     public ResponseEntity<UserResponse> getUser(@PathVariable UUID id) {

--- a/src/main/java/com/union/union/global/config/DevRequestLoggingFilter.java
+++ b/src/main/java/com/union/union/global/config/DevRequestLoggingFilter.java
@@ -32,6 +32,24 @@ public class DevRequestLoggingFilter extends OncePerRequestFilter {
             FilterChain filterChain
     ) throws ServletException, IOException {
 
+        // multipart 요청은 wrapper 로 감싸지 않고 그대로 통과시킨다.
+        // ReReadableRequestWrapper.getInputStream() 이 ByteArrayInputStream 을 반환하면
+        // Tomcat 의 multipart parser 가 boundary/parts 를 정상적으로 분리하지 못해
+        // @RequestPart 가 MissingServletRequestPartException 으로 실패한다.
+        String contentType = request.getContentType();
+        if (contentType != null && contentType.toLowerCase().startsWith("multipart/")) {
+            ContentCachingResponseWrapper wrappedResponse = new ContentCachingResponseWrapper(response);
+            long start = System.currentTimeMillis();
+            try {
+                filterChain.doFilter(request, wrappedResponse);
+            } finally {
+                long duration = System.currentTimeMillis() - start;
+                logRequest(request, wrappedResponse, new byte[0], duration);
+                wrappedResponse.copyBodyToResponse();
+            }
+            return;
+        }
+
         // body를 미리 읽어 두고 다운스트림에서도 재사용 가능한 wrapper
         byte[] bodyBytes = request.getInputStream().readAllBytes();
         HttpServletRequest reReadableRequest = new ReReadableRequestWrapper(request, bodyBytes);

--- a/src/main/java/com/union/union/global/infra/gcs/GcsService.java
+++ b/src/main/java/com/union/union/global/infra/gcs/GcsService.java
@@ -35,6 +35,13 @@ public class GcsService {
     @Value("${spring.cloud.gcp.storage.bucket}")
     private String bucketName;
 
+    /**
+     * 배너 이미지 전용 버킷 — 미니앱 번들 버킷과 분리.
+     * 라이프사이클 정책(배너=long-cache, 미니앱=immutable) 및 권한 정책 분리 목적.
+     */
+    @Value("${banner.bucket.name:union-app-banners}")
+    private String bannerBucketName;
+
     private static final String CDN_URL_CACHE_PREFIX = "cdn:signed-url:";
     private static final long CDN_URL_EXPIRATION_SECONDS = 3600;      // CDN URL 유효: 1시간
     private static final long REDIS_CACHE_SECONDS = 3000;             // Redis 캐시: 50분 (10분 버퍼)
@@ -71,6 +78,29 @@ public class GcsService {
                 .build();
         storage.create(blobInfo, file.getBytes());
         return objectPath;
+    }
+
+    /**
+     * 배너 이미지를 배너 버킷에 업로드하고 공개 HTTPS URL 반환.
+     * 버킷은 사전에 public read(allUsers:objectViewer) 권한이 설정되어 있어야 함.
+     *
+     * @return https://storage.googleapis.com/{bannerBucket}/{objectPath}
+     */
+    public String uploadBannerImage(MultipartFile file, String objectPath) throws IOException {
+        BlobId blobId = BlobId.of(bannerBucketName, objectPath);
+        BlobInfo blobInfo = BlobInfo.newBuilder(blobId)
+                .setContentType(file.getContentType() != null ? file.getContentType() : "image/png")
+                .setCacheControl("public, max-age=86400")
+                .build();
+        storage.create(blobInfo, file.getBytes());
+        return getBannerPublicUrl(objectPath);
+    }
+
+    /**
+     * 배너 이미지 공개 URL. 배너 버킷이 public read 면 그대로 fetch 가능.
+     */
+    public String getBannerPublicUrl(String objectPath) {
+        return "https://storage.googleapis.com/" + bannerBucketName + "/" + objectPath;
     }
 
     /**

--- a/src/main/java/com/union/union/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/union/union/global/security/config/SecurityConfig.java
@@ -65,6 +65,9 @@ public class SecurityConfig {
                 // GET summary/events: 퍼블리셔 대시보드 (@PreAuthorize 로 세부 인가)
                 .requestMatchers(HttpMethod.GET, "/api/v1/analytics/**").authenticated()
 
+                // Banner endpoints (Public) — Home 캐러셀 노출용
+                .requestMatchers(HttpMethod.GET, "/banners").permitAll()
+
                 // MiniApp endpoints (Public)
                 .requestMatchers(HttpMethod.GET, "/mini-apps").permitAll()
                 .requestMatchers(HttpMethod.GET, "/mini-apps/popular").permitAll()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,6 +50,11 @@ spring:
       storage:
         bucket: ${GCS_BUCKET_NAME:union-app-miniapps}
 
+banner:
+  bucket:
+    # 배너 이미지 전용 버킷. 사전에 GCP 콘솔에서 생성 + public read(allUsers:objectViewer) 필요.
+    name: ${BANNER_BUCKET_NAME:union-app-banners}
+
 jwt:
   secret: ${JWT_SECRET:union-super-app-jwt-secret-key-must-be-at-least-256-bits-long-for-hs256}
   access-token-expiration: 1800000     # 30분


### PR DESCRIPTION
## Summary

iOS Home 캐러셀 / 프로필 / 검색 결과 카드 Mock 제거를 위한 백엔드 보강.

### 1. Banner 도메인 신설 (commit 3·4)
- \`banners\` 테이블 + Entity (BaseEntity 상속, ddl-auto 자동 생성)
- \`GET /banners\` public 엔드포인트 — 5분 캐시, active window (start_at/end_at) 필터, sort_order 정렬
- \`POST /api/dev/seed/banner\` (local profile, multipart) — GCS 업로드 + DB INSERT
- GCS 배너 전용 버킷 \`union-app-banners\` 지원 (env: \`BANNER_BUCKET_NAME\`)
- 인프라(버킷 생성, public read, SA IAM)는 본 PR 기준 콘솔 작업 완료

### 2. /api/v1/users/me (commit 1)
- iOS ProfileView / 미니앱 SDK AuthBridge.getUserProfile() 진입점
- 별도 스키마 변경 없음. 기존 UserResponse DTO 재사용

### 3. MiniAppLiteDto 보강 (commit 2)
- description, createdAt 노출 — iOS NEW 배지 / 카드 본문 렌더용
- rating 4.5 하드코딩 → null. 별점 도메인(user_app_ratings) 도입까지 보류

### 4. DevRequestLoggingFilter multipart fix (commit 5)
- local profile 한정 필터가 InputStream 을 미리 통째로 읽어 Tomcat multipart parser 가 boundary 를 못 잡던 버그
- multipart/* Content-Type 은 wrapper 우회로 처리
- \`/api/dev/seed/banner\` 와 기존 \`/api/dev/seed/app\` 둘 다 로컬에서 정상 동작 확인

## Test plan
- [x] \`./gradlew compileJava\` 성공
- [x] 로컬 bootRun → \`GET /banners\` 200 OK
- [x] \`POST /api/dev/seed/banner\` multipart → 201, GCS 업로드 + DB row
- [x] \`GET /banners\` 응답에 신규 배너 포함
- [x] GCS public URL 직접 접근 — HTTP 200, image/png
- [ ] (Cloud Run 배포 후) iOS 시뮬레이터에서 Home 캐러셀 V5 이미지 렌더 확인