### PR TITLE
fix(miniapp,banner): DEPLOYED 라이브 필터 환원 + Banner 캐시 직렬화 수정

### DIFF
--- a/src/main/java/com/union/union/domain/analytics/service/AnalyticsIngestService.java
+++ b/src/main/java/com/union/union/domain/analytics/service/AnalyticsIngestService.java
@@ -144,7 +144,7 @@ public class AnalyticsIngestService {
         // 캐시 히트 → 검증 완료된 appId
         if (redisService.hasKey(cacheKey)) return;
 
-        boolean exists = miniAppRepository.existsByAppIdAndStatus(appId, MiniAppStatus.DEPLOYED);
+        boolean exists = miniAppRepository.existsByAppIdAndStatus(appId, MiniAppStatus.APPROVED);
         if (!exists) {
             throw new EntityNotFoundException(
                 "Mini-app not found or not deployed: appId=" + appId

--- a/src/main/java/com/union/union/domain/appversion/service/AppVersionService.java
+++ b/src/main/java/com/union/union/domain/appversion/service/AppVersionService.java
@@ -10,6 +10,7 @@ import com.union.union.domain.appversion.dto.TestLinkResponseDto;
 import com.union.union.domain.appversion.entity.AppVersion;
 import com.union.union.domain.appversion.repository.AppVersionRepository;
 import com.union.union.domain.miniapp.entity.MiniApp;
+import com.union.union.domain.miniapp.entity.MiniAppStatus;
 import com.union.union.domain.miniapp.repository.MiniAppRepository;
 import com.union.union.domain.notification.service.NotificationService;
 import com.union.union.domain.workspace.service.WorkspaceAuthorizationService;
@@ -171,8 +172,12 @@ public class AppVersionService {
 
         version.deploy();
 
+        // 라이브 노출은 MiniApp.status == APPROVED 기준. 버전 배포 시 부모 MiniApp 이
+        // APPROVED 가 아니면 안전망으로 APPROVED 로 복원만 한다 (status 를 따로 DEPLOYED 로 옮기지 않음).
         MiniApp miniApp = version.getMiniApp();
-        miniApp.deploy();
+        if (miniApp.getStatus() != MiniAppStatus.APPROVED) {
+            miniApp.approve();
+        }
 
         log.info("AppVersion 배포 완료 (DEPLOYED). versionId={}, miniAppId={}", versionId, miniApp.getId());
         notificationService.sendToPublisher(

--- a/src/main/java/com/union/union/domain/auth/controller/DevSeedController.java
+++ b/src/main/java/com/union/union/domain/auth/controller/DevSeedController.java
@@ -323,8 +323,8 @@ public class DevSeedController {
     private Map<String, Object> seedApp(Workspace workspace, MiniAppCategory category,
                                          String name, String description,
                                          String tags, String version) {
-        // 이미 동일 이름의 DEPLOYED 앱이 있으면 스킵
-        Optional<MiniApp> existing = miniAppRepository.findByStatus(MiniAppStatus.DEPLOYED)
+        // 이미 동일 이름의 APPROVED 앱이 있으면 스킵
+        Optional<MiniApp> existing = miniAppRepository.findByStatus(MiniAppStatus.APPROVED)
                 .stream()
                 .filter(a -> a.getName().equals(name) &&
                         a.getWorkspace().getWorkspaceId().equals(workspace.getWorkspaceId()))
@@ -346,7 +346,7 @@ public class DevSeedController {
                 .workspace(workspace)
                 .status(MiniAppStatus.PENDING)
                 .build());
-        app.deploy();
+        app.approve();
         miniAppRepository.save(app);
 
         // AppVersion: DRAFT → UPLOADED → tested → IN_REVIEW → ACCEPTED → DEPLOYED

--- a/src/main/java/com/union/union/domain/banner/service/BannerService.java
+++ b/src/main/java/com/union/union/domain/banner/service/BannerService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -28,7 +29,7 @@ public class BannerService {
         return bannerRepository.findActiveBanners(LocalDateTime.now())
                 .stream()
                 .map(BannerResponseDto::from)
-                .toList();
+                .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/java/com/union/union/domain/dev/service/DevSeedService.java
+++ b/src/main/java/com/union/union/domain/dev/service/DevSeedService.java
@@ -98,7 +98,7 @@ public class DevSeedService {
                 .category(category)
                 .tags(tags)
                 .workspace(workspace)
-                .status(MiniAppStatus.DEPLOYED)
+                .status(MiniAppStatus.APPROVED)
                 .build();
         miniApp.updateAppId(appId);
         miniApp = miniAppRepository.save(miniApp);

--- a/src/main/java/com/union/union/domain/miniapp/entity/MiniApp.java
+++ b/src/main/java/com/union/union/domain/miniapp/entity/MiniApp.java
@@ -79,10 +79,6 @@ public class MiniApp extends BaseEntity {
         this.status = MiniAppStatus.APPROVED;
     }
 
-    public void deploy() {
-        this.status = MiniAppStatus.DEPLOYED;
-    }
-
     public void reject() {
         this.status = MiniAppStatus.REJECTED;
     }

--- a/src/main/java/com/union/union/domain/miniapp/entity/MiniAppStatus.java
+++ b/src/main/java/com/union/union/domain/miniapp/entity/MiniAppStatus.java
@@ -3,6 +3,5 @@ package com.union.union.domain.miniapp.entity;
 public enum MiniAppStatus {
     PENDING,
     APPROVED,
-    REJECTED,
-    DEPLOYED
+    REJECTED
 }

--- a/src/main/java/com/union/union/domain/miniapp/service/MiniAppCacheService.java
+++ b/src/main/java/com/union/union/domain/miniapp/service/MiniAppCacheService.java
@@ -21,7 +21,7 @@ public class MiniAppCacheService {
 
     @Cacheable(value = "discovery_popular", sync = true)
     public List<MiniAppLiteDto> getPopularAppsCache() {
-        return miniAppRepository.findPopularMiniApps(MiniAppStatus.DEPLOYED, PageRequest.of(0, 10))
+        return miniAppRepository.findPopularMiniApps(MiniAppStatus.APPROVED, PageRequest.of(0, 10))
                 .stream()
                 .map(MiniAppLiteDto::from)
                 .collect(Collectors.toList());
@@ -29,7 +29,7 @@ public class MiniAppCacheService {
 
     @Cacheable(value = "discovery_new", sync = true)
     public List<MiniAppLiteDto> getNewAppsCache() {
-        return miniAppRepository.findNewMiniApps(MiniAppStatus.DEPLOYED, PageRequest.of(0, 10))
+        return miniAppRepository.findNewMiniApps(MiniAppStatus.APPROVED, PageRequest.of(0, 10))
                 .stream()
                 .map(MiniAppLiteDto::from)
                 .collect(Collectors.toList());

--- a/src/main/java/com/union/union/domain/miniapp/service/MiniAppSearchService.java
+++ b/src/main/java/com/union/union/domain/miniapp/service/MiniAppSearchService.java
@@ -34,7 +34,7 @@ public class MiniAppSearchService {
             redisService.incrementScore(SEARCH_TRENDING_KEY, keyword.trim(), 1.0);
         }
 
-        return miniAppRepository.searchByKeyword(keyword, MiniAppStatus.DEPLOYED, pageable)
+        return miniAppRepository.searchByKeyword(keyword, MiniAppStatus.APPROVED, pageable)
                 .stream()
                 .map(MiniAppLiteDto::from)
                 .collect(Collectors.toList());
@@ -47,7 +47,7 @@ public class MiniAppSearchService {
 
         String jamoPrefix = com.union.union.domain.miniapp.utils.KoreanUtils.decompose(keyword.trim().toLowerCase());
 
-        return miniAppRepository.findByStatusAndSearchableNameStartingWith(MiniAppStatus.DEPLOYED, jamoPrefix, pageable)
+        return miniAppRepository.findByStatusAndSearchableNameStartingWith(MiniAppStatus.APPROVED, jamoPrefix, pageable)
                 .stream()
                 .map(MiniAppLiteDto::from)
                 .collect(Collectors.toList());
@@ -57,7 +57,7 @@ public class MiniAppSearchService {
         MiniAppCategory category = miniAppCategoryRepository.findById(categoryId)
                 .orElseThrow(() -> new com.union.union.global.common.exception.EntityNotFoundException("카테고리를 찾을 수 없습니다"));
 
-        return miniAppRepository.findByCategoryAndStatus(category, MiniAppStatus.DEPLOYED, pageable)
+        return miniAppRepository.findByCategoryAndStatus(category, MiniAppStatus.APPROVED, pageable)
                 .stream()
                 .map(MiniAppLiteDto::from)
                 .collect(Collectors.toList());

--- a/src/main/java/com/union/union/domain/miniapp/service/MiniAppService.java
+++ b/src/main/java/com/union/union/domain/miniapp/service/MiniAppService.java
@@ -81,7 +81,7 @@ public class MiniAppService {
     // TODO: 커서 페이징 구현 (기획 확정 후)
     @Cacheable(value = "miniApps", key = "'approved'")
     public List<MiniAppResponseDto> getApprovedMiniApps() {
-        return miniAppRepository.findByStatus(MiniAppStatus.DEPLOYED)
+        return miniAppRepository.findByStatus(MiniAppStatus.APPROVED)
                 .stream()
                 .map(MiniAppResponseDto::from)
                 .collect(Collectors.toList());
@@ -89,7 +89,7 @@ public class MiniAppService {
 
     @Cacheable(value = "popularMiniApps", key = "#limit")
     public List<MiniAppResponseDto> getPopularMiniApps(int limit) {
-        return miniAppRepository.findPopularMiniApps(MiniAppStatus.DEPLOYED, PageRequest.of(0, limit))
+        return miniAppRepository.findPopularMiniApps(MiniAppStatus.APPROVED, PageRequest.of(0, limit))
                 .stream()
                 .map(MiniAppResponseDto::from)
                 .collect(Collectors.toList());
@@ -101,10 +101,10 @@ public class MiniAppService {
 
         // 1. 같은 대학 인기 앱 (Top 5)
         List<MiniApp> universityPopular = miniAppRepository.findRecommendedByUniversity(
-                user.getUniversityName(), MiniAppStatus.DEPLOYED, PageRequest.of(0, 5));
+                user.getUniversityName(), MiniAppStatus.APPROVED, PageRequest.of(0, 5));
 
         // 2. 내가 최근에 사용한 앱 (Top 5)
-        List<MiniApp> myRecent = miniAppRepository.findRecentByUser(userId, MiniAppStatus.DEPLOYED, PageRequest.of(0, 5));
+        List<MiniApp> myRecent = miniAppRepository.findRecentByUser(userId, MiniAppStatus.APPROVED, PageRequest.of(0, 5));
 
         // 3. ID 기반 중복 제거 및 결합
         java.util.LinkedHashMap<Long, MiniApp> combined = new java.util.LinkedHashMap<>();
@@ -113,7 +113,7 @@ public class MiniAppService {
 
         // 4. 결과가 부족하면 글로벌 인기 앱 추가
         if (combined.size() < 5) {
-            List<MiniApp> globalPopular = miniAppRepository.findPopularMiniApps(MiniAppStatus.DEPLOYED, PageRequest.of(0, 10));
+            List<MiniApp> globalPopular = miniAppRepository.findPopularMiniApps(MiniAppStatus.APPROVED, PageRequest.of(0, 10));
             for (MiniApp popular : globalPopular) {
                 combined.putIfAbsent(popular.getId(), popular);
                 if (combined.size() >= 10) break;
@@ -159,7 +159,7 @@ public class MiniAppService {
         if (userId == null) {
             return java.util.Collections.emptyList();
         }
-        return miniAppRepository.findRecentByUser(userId, MiniAppStatus.DEPLOYED, PageRequest.of(0, 5))
+        return miniAppRepository.findRecentByUser(userId, MiniAppStatus.APPROVED, PageRequest.of(0, 5))
                 .stream()
                 .map(MiniAppLiteDto::from)
                 .collect(Collectors.toList());
@@ -197,7 +197,7 @@ public class MiniAppService {
         MiniApp miniApp = miniAppRepository.findById(id)
                 .orElseThrow(() -> new EntityNotFoundException("MiniApp을 찾을 수 없습니다"));
 
-        if (miniApp.getStatus() != MiniAppStatus.DEPLOYED) {
+        if (miniApp.getStatus() != MiniAppStatus.APPROVED) {
             throw new UnauthorizedAccessException("배포되지 않은 MiniApp입니다");
         }
 


### PR DESCRIPTION
## Summary

운영 라이브에서 발생한 두 건의 500 폭사를 잡습니다.

### 1. `/app-versions/{id}/deploy` 500 (Publisher 대시보드 영향)
PR #42 에서 `MiniAppStatus.DEPLOYED` 를 추가하고 `AppVersionService.deploy()` 가 `MiniApp.status` 를 `APPROVED → DEPLOYED` 로 옮기도록 변경했으나, 운영 DB(Neon) 의 \`mini_apps_status_check\` CHECK 제약이 옛 enum 값(\`PENDING/APPROVED/REJECTED\`)만 허용 — \`SQLState 23514 DataIntegrityViolationException\` 으로 폭사.
- \`Hibernate ddl-auto: update\` 는 기존 CHECK 제약을 자동 갱신하지 않음 (알려진 한계).
- 동시에 라이브 필터를 \`DEPLOYED\` 로 옮긴 영향으로, DB 의 모든 미니앱(\`APPROVED\`)이 앱 화면에서 사라짐.

해결: 라이프사이클을 PR #42 이전(\`PENDING → APPROVED/REJECTED\`)으로 환원하고, \`/deploy\` 는 \`AppVersion.status\` 만 \`DEPLOYED\` 로 이동시키는 원래 의미로 되돌림.

### 2. `GET /banners` 500 (iOS 앱 영향)
\`BannerService.getActiveBanners()\` 가 \`Stream.toList()\` 를 사용 → \`ImmutableCollections\$ListN\`(final) 반환 → \`GenericJackson2JsonRedisSerializer\` + \`DefaultTyping.NON_FINAL\` 조합에서 type-id wrapper 가 박히지 않아 cache hit 라운드트립 시 \`Unexpected token (START_ARRAY), expected VALUE_STRING\` 으로 폭사.

해결: \`.collect(Collectors.toList())\` 로 변경해 다른 캐시 서비스(MiniAppCacheService 등)와 컨벤션 통일.

## Changes

- 라이브 필터 14곳: \`MiniAppStatus.DEPLOYED\` → \`APPROVED\` 환원
  - \`MiniAppService\`, \`MiniAppCacheService\`, \`MiniAppSearchService\`
  - \`AnalyticsIngestService\`, \`DevSeedService\`, \`DevSeedController\`
- \`AppVersionService.deploy()\`: \`miniApp.deploy()\` 호출 제거, APPROVED 안전망 if-check 복원
- \`MiniApp.deploy()\` 메서드 제거
- \`MiniAppStatus\` 에서 \`DEPLOYED\` enum 값 제거
- \`BannerService.getActiveBanners()\`: \`.toList()\` → \`.collect(Collectors.toList())\`

## Test plan

- [x] \`./gradlew compileJava\` 로컬 컴파일 통과
- [x] 라이브(\`union-api-00008-mk4\`) 헬스체크:
  - \`GET /banners\` cache miss/hit 모두 200
  - \`GET /mini-apps\`, \`/mini-apps/discovery\`, \`/mini-apps/popular\` 200
- [ ] Publisher 대시보드에서 \`POST /app-versions/{id}/deploy\` 호출 시 200 응답 (배포 후 확인 필요)