### PR TITLE
feat(miniapp): 미니앱 아이콘 업로드 API 구현

### DIFF
--- a/src/main/java/com/union/union/domain/miniapp/controller/MiniAppController.java
+++ b/src/main/java/com/union/union/domain/miniapp/controller/MiniAppController.java
@@ -3,6 +3,7 @@ package com.union.union.domain.miniapp.controller;
 import com.union.union.domain.miniapp.dto.*;
 import com.union.union.domain.miniapp.service.MiniAppSearchService;
 import com.union.union.domain.miniapp.service.MiniAppService;
+import com.union.union.global.infra.gcs.dto.GcsSignedUrlResponseDto;
 import com.union.union.global.security.jwt.JwtUserPrincipal;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
@@ -123,5 +124,27 @@ public class MiniAppController {
     @GetMapping("/search/popular")
     public ResponseEntity<List<String>> getPopularKeywords() {
         return ResponseEntity.ok(miniAppSearchService.getPopularKeywords(5));
+    }
+
+    @PostMapping("/{id}/icon/upload-url")
+    @PreAuthorize("hasRole('PUBLISHER')")
+    public ResponseEntity<GcsSignedUrlResponseDto> getIconUploadUrl(
+            @PathVariable Long id,
+            @Valid @RequestBody IconUploadUrlRequestDto request,
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        GcsSignedUrlResponseDto response = miniAppService.getIconUploadUrl(id, principal.userId(), request.filename());
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{id}/icon")
+    @PreAuthorize("hasRole('PUBLISHER')")
+    public ResponseEntity<MiniAppResponseDto> updateIcon(
+            @PathVariable Long id,
+            @Valid @RequestBody UpdateIconRequestDto request,
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        MiniAppResponseDto response = miniAppService.updateIconUrl(id, principal.userId(), request.iconUrl());
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/union/union/domain/miniapp/dto/IconUploadUrlRequestDto.java
+++ b/src/main/java/com/union/union/domain/miniapp/dto/IconUploadUrlRequestDto.java
@@ -1,0 +1,8 @@
+package com.union.union.domain.miniapp.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record IconUploadUrlRequestDto(
+        @NotBlank String filename
+) {
+}

--- a/src/main/java/com/union/union/domain/miniapp/dto/UpdateIconRequestDto.java
+++ b/src/main/java/com/union/union/domain/miniapp/dto/UpdateIconRequestDto.java
@@ -1,0 +1,8 @@
+package com.union.union.domain.miniapp.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateIconRequestDto(
+        @NotBlank String iconUrl
+) {
+}

--- a/src/main/java/com/union/union/domain/miniapp/entity/MiniApp.java
+++ b/src/main/java/com/union/union/domain/miniapp/entity/MiniApp.java
@@ -75,6 +75,10 @@ public class MiniApp extends BaseEntity {
         this.appId = appId;
     }
 
+    public void updateIconUrl(String iconUrl) {
+        this.iconUrl = iconUrl;
+    }
+
     public void approve() {
         this.status = MiniAppStatus.APPROVED;
     }

--- a/src/main/java/com/union/union/domain/miniapp/service/MiniAppService.java
+++ b/src/main/java/com/union/union/domain/miniapp/service/MiniAppService.java
@@ -5,6 +5,7 @@ import com.union.union.domain.appversion.entity.VersionStatus;
 import com.union.union.domain.appversion.repository.AppVersionRepository;
 import com.union.union.domain.miniapp.dto.*;
 import com.union.union.domain.miniapp.entity.MiniApp;
+import com.union.union.global.infra.gcs.dto.GcsSignedUrlResponseDto;
 import com.union.union.domain.miniapp.entity.MiniAppCategory;
 import com.union.union.domain.miniapp.entity.MiniAppStatus;
 import com.union.union.domain.miniapp.repository.MiniAppCategoryRepository;
@@ -190,6 +191,23 @@ public class MiniAppService {
                 .stream()
                 .map(MiniAppResponseDto::from)
                 .collect(Collectors.toList());
+    }
+
+    public GcsSignedUrlResponseDto getIconUploadUrl(Long miniAppId, UUID publisherId, String filename) {
+        MiniApp miniApp = miniAppRepository.findById(miniAppId)
+                .orElseThrow(() -> new EntityNotFoundException("MiniApp을 찾을 수 없습니다"));
+        workspaceAuthorizationService.validateMembership(miniApp.getWorkspace().getWorkspaceId(), publisherId);
+        return gcsService.getIconUploadUrl(miniAppId, filename);
+    }
+
+    @Transactional
+    @CacheEvict(value = "miniApps", allEntries = true)
+    public MiniAppResponseDto updateIconUrl(Long miniAppId, UUID publisherId, String iconUrl) {
+        MiniApp miniApp = miniAppRepository.findById(miniAppId)
+                .orElseThrow(() -> new EntityNotFoundException("MiniApp을 찾을 수 없습니다"));
+        workspaceAuthorizationService.validateMembership(miniApp.getWorkspace().getWorkspaceId(), publisherId);
+        miniApp.updateIconUrl(iconUrl);
+        return MiniAppResponseDto.from(miniApp);
     }
 
     @Transactional

--- a/src/main/java/com/union/union/global/infra/gcs/GcsService.java
+++ b/src/main/java/com/union/union/global/infra/gcs/GcsService.java
@@ -104,6 +104,28 @@ public class GcsService {
     }
 
     /**
+     * 미니앱 아이콘 업로드용 GCS Signed PUT URL (5분) + 공개 다운로드 URL.
+     * 아이콘은 배너 버킷(public read)의 icons/{miniAppId}/ 경로에 저장.
+     */
+    public GcsSignedUrlResponseDto getIconUploadUrl(Long miniAppId, String filename) {
+        String ext = filename.contains(".") ? filename.substring(filename.lastIndexOf('.')) : "";
+        String blobName = String.format("icons/%d/%s%s", miniAppId, UUID.randomUUID(), ext);
+
+        BlobInfo blobInfo = BlobInfo.newBuilder(bannerBucketName, blobName).build();
+
+        URL signedUrl = storage.signUrl(
+                blobInfo,
+                5,
+                TimeUnit.MINUTES,
+                Storage.SignUrlOption.httpMethod(HttpMethod.PUT),
+                Storage.SignUrlOption.withV4Signature()
+        );
+
+        String publicUrl = "https://storage.googleapis.com/" + bannerBucketName + "/" + blobName;
+        return new GcsSignedUrlResponseDto(signedUrl.toString(), publicUrl);
+    }
+
+    /**
      * CDN Signed URL 조회 (Redis 캐시 → 미스 시 생성)
      */
     public String getCdnDownloadUrl(String objectPath) {


### PR DESCRIPTION
- GcsService: getIconUploadUrl() 추가 (배너 버킷 public 경로 활용)
- MiniApp: updateIconUrl() 메서드 추가
- POST /mini-apps/{id}/icon/upload-url — Signed PUT URL 발급
- PATCH /mini-apps/{id}/icon — iconUrl DB 저장