### PR TITLE
feat(notification): Publisher 알림 발송 시스템

### DIFF
--- a/src/main/java/com/union/union/domain/appversion/dto/TestBundleResponseDto.java
+++ b/src/main/java/com/union/union/domain/appversion/dto/TestBundleResponseDto.java
@@ -7,6 +7,8 @@ public record TestBundleResponseDto(
         Long miniAppId,
         String miniAppName,
         String versionNumber,
-        String bundleUrl
+        String bundleUrl,
+        /** reverse-domain appId (예: com.union.soccer). Bridge `notification` 모듈이 자기 미니앱 식별에 사용. */
+        String appId
 ) {
 }

--- a/src/main/java/com/union/union/domain/appversion/service/AppVersionService.java
+++ b/src/main/java/com/union/union/domain/appversion/service/AppVersionService.java
@@ -95,7 +95,8 @@ public class AppVersionService {
                 version.getMiniApp().getId(),
                 version.getMiniApp().getName(),
                 version.getVersionNumber(),
-                signedUrl);
+                signedUrl,
+                version.getMiniApp().getAppId());
     }
 
     @Transactional

--- a/src/main/java/com/union/union/domain/miniapp/dto/MiniAppResponseDto.java
+++ b/src/main/java/com/union/union/domain/miniapp/dto/MiniAppResponseDto.java
@@ -16,6 +16,7 @@ public record MiniAppResponseDto(
     MiniAppStatus status,
     String tags,
     List<PermissionScope> permissions,
+    String appId,
     LocalDateTime createdAt
 ) {
     public static MiniAppResponseDto from(MiniApp miniApp) {
@@ -28,6 +29,7 @@ public record MiniAppResponseDto(
             miniApp.getStatus(),
             miniApp.getTags(),
             miniApp.getPermissions(),
+            miniApp.getAppId(),
             miniApp.getCreatedAt()
         );
     }

--- a/src/main/java/com/union/union/domain/miniapp/service/MiniAppService.java
+++ b/src/main/java/com/union/union/domain/miniapp/service/MiniAppService.java
@@ -14,6 +14,7 @@ import com.union.union.domain.miniapp.usage.dto.MiniAppUsageStatsDto;
 import com.union.union.domain.miniapp.usage.dto.PublisherStatisticsResponseDto;
 import com.union.union.domain.miniapp.usage.entity.MiniAppUsage;
 import com.union.union.domain.miniapp.usage.repository.MiniAppUsageRepository;
+import com.union.union.domain.subscription.service.SubscriptionService;
 import com.union.union.domain.user.entity.User;
 import com.union.union.domain.user.repository.UserRepository;
 import com.union.union.domain.workspace.entity.Workspace;
@@ -51,6 +52,7 @@ public class MiniAppService {
     private final GcsService gcsService;
     private final MiniAppSearchService miniAppSearchService;
     private final MiniAppCacheService miniAppCacheService;
+    private final SubscriptionService subscriptionService;
 
     @Transactional
     @CacheEvict(value = "miniApps", allEntries = true)
@@ -243,6 +245,9 @@ public class MiniAppService {
                 .orElseThrow(() -> new EntityNotFoundException("배포된 버전이 없습니다"));
 
         miniAppUsageRepository.save(MiniAppUsage.create(userId, id));
+
+        // 첫 실행 시 자동 구독 (멱등). 알림 발송 대상 산정 기준.
+        subscriptionService.autoSubscribe(userId, id);
 
         return gcsService.getCdnDownloadUrl(deployedVersion.getBuildFileUrl());
     }

--- a/src/main/java/com/union/union/domain/notification/controller/PublisherNotificationController.java
+++ b/src/main/java/com/union/union/domain/notification/controller/PublisherNotificationController.java
@@ -1,0 +1,49 @@
+package com.union.union.domain.notification.controller;
+
+import com.union.union.domain.notification.dto.PublisherSendNotificationRequest;
+import com.union.union.domain.notification.dto.PublisherSendNotificationResponse;
+import com.union.union.domain.notification.service.NotificationService;
+import com.union.union.global.security.apikey.PublisherApiKeyPrincipal;
+import com.union.union.global.security.jwt.JwtUserPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class PublisherNotificationController {
+
+    private final NotificationService notificationService;
+
+    /**
+     * Publisher 백엔드 → Spring (X-Union-Api-Key 헤더로 인증).
+     * 미니앱 구독자에게 푸시 알림을 발송.
+     */
+    @PostMapping("/api/v1/publishers/notifications")
+    @PreAuthorize("hasAuthority('SCOPE_notifications:send')")
+    public ResponseEntity<PublisherSendNotificationResponse> sendWithApiKey(
+            @Valid @RequestBody PublisherSendNotificationRequest request,
+            @AuthenticationPrincipal PublisherApiKeyPrincipal principal
+    ) {
+        PublisherSendNotificationResponse result =
+                notificationService.sendByPublisher(principal.publisherId(), request);
+        return ResponseEntity.ok(result);
+    }
+
+    /**
+     * 대시보드 → Spring (JWT 인증). API Key 발급 전 테스트용.
+     */
+    @PostMapping("/api/v1/publishers/me/notifications")
+    @PreAuthorize("hasRole('PUBLISHER')")
+    public ResponseEntity<PublisherSendNotificationResponse> sendAsAuthenticatedPublisher(
+            @Valid @RequestBody PublisherSendNotificationRequest request,
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        PublisherSendNotificationResponse result =
+                notificationService.sendByPublisher(principal.userId(), request);
+        return ResponseEntity.ok(result);
+    }
+}

--- a/src/main/java/com/union/union/domain/notification/dto/PublisherSendNotificationRequest.java
+++ b/src/main/java/com/union/union/domain/notification/dto/PublisherSendNotificationRequest.java
@@ -1,0 +1,38 @@
+package com.union.union.domain.notification.dto;
+
+import com.union.union.domain.notification.entity.DeeplinkType;
+import com.union.union.domain.notification.entity.NotificationCategory;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record PublisherSendNotificationRequest(
+        @NotBlank
+        @Size(max = 100, message = "targetAppId 는 최대 100자")
+        String targetAppId,
+
+        @NotBlank
+        @Size(max = 120, message = "title 은 최대 120자")
+        String title,
+
+        @NotBlank
+        @Size(max = 500, message = "body 는 최대 500자")
+        String body,
+
+        @Size(max = 500)
+        String imageUrl,
+
+        @NotNull
+        NotificationCategory category,
+
+        DeeplinkType deeplinkType,
+
+        @Size(max = 500)
+        String targetPath,
+
+        @Size(max = 500)
+        String targetWebUrl,
+
+        @Size(max = 200)
+        String targetInternalRoute
+) {}

--- a/src/main/java/com/union/union/domain/notification/dto/PublisherSendNotificationResponse.java
+++ b/src/main/java/com/union/union/domain/notification/dto/PublisherSendNotificationResponse.java
@@ -1,0 +1,7 @@
+package com.union.union.domain.notification.dto;
+
+public record PublisherSendNotificationResponse(
+        Long campaignId,
+        long sentTokenCount,
+        long subscriberCount
+) {}

--- a/src/main/java/com/union/union/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/union/union/domain/notification/service/NotificationService.java
@@ -1,14 +1,21 @@
 package com.union.union.domain.notification.service;
 
+import com.union.union.domain.miniapp.entity.MiniApp;
+import com.union.union.domain.miniapp.repository.MiniAppRepository;
 import com.union.union.domain.notification.dto.InboxResponseDto;
+import com.union.union.domain.notification.dto.PublisherSendNotificationRequest;
+import com.union.union.domain.notification.dto.PublisherSendNotificationResponse;
 import com.union.union.domain.notification.dto.RegisterTokenRequestDto;
 import com.union.union.domain.notification.dto.SendNotificationRequestDto;
 import com.union.union.domain.notification.entity.*;
 import com.union.union.domain.notification.repository.*;
 import com.union.union.domain.publisher.entity.Publisher;
 import com.union.union.domain.publisher.repository.PublisherRepository;
+import com.union.union.domain.subscription.entity.MiniAppSubscription;
+import com.union.union.domain.subscription.repository.MiniAppSubscriptionRepository;
 import com.union.union.domain.user.entity.User;
 import com.union.union.domain.user.repository.UserRepository;
+import com.union.union.domain.workspace.service.WorkspaceAuthorizationService;
 import com.union.union.global.common.exception.EntityNotFoundException;
 import com.union.union.global.infra.fcm.FcmService;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +44,9 @@ public class NotificationService {
     private final PublisherRepository publisherRepository;
     private final UserRepository userRepository;
     private final FcmService fcmService;
+    private final MiniAppRepository miniAppRepository;
+    private final MiniAppSubscriptionRepository subscriptionRepository;
+    private final WorkspaceAuthorizationService workspaceAuthorizationService;
 
     // ── 토큰 등록/삭제 ──────────────────────────────────────────
 
@@ -176,6 +186,89 @@ public class NotificationService {
         List<String> tokens = userFcmTokenRepository.findTokensByUserId(userId);
         fcmService.sendMulticast(tokens, title, body);
     }
+
+    // ── Publisher 발송 ───────────────────────────────────────────
+
+    public PublisherSendNotificationResponse sendByPublisher(
+            UUID senderPublisherId,
+            PublisherSendNotificationRequest request
+    ) {
+        MiniApp miniApp = miniAppRepository.findByAppId(request.targetAppId())
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "MiniApp을 찾을 수 없습니다. targetAppId=" + request.targetAppId()));
+
+        // publisher가 미니앱 소유 워크스페이스의 멤버인지 검증 → 아니면 403
+        workspaceAuthorizationService.validateMembership(
+                miniApp.getWorkspace().getWorkspaceId(), senderPublisherId);
+
+        NotificationCampaign campaign = campaignRepository.save(NotificationCampaign.builder()
+                .senderType(SenderType.MINIAPP)
+                .senderMiniappId(miniApp.getId())
+                .senderPublisherId(senderPublisherId)
+                .category(request.category())
+                .title(request.title())
+                .body(request.body())
+                .imageUrl(request.imageUrl())
+                .deeplinkType(request.deeplinkType())
+                .targetAppId(miniApp.getAppId())
+                .targetPath(request.targetPath())
+                .targetWebUrl(request.targetWebUrl())
+                .targetInternalRoute(request.targetInternalRoute())
+                .build());
+
+        FanOutStats stats = fanOutToSubscribers(campaign, miniApp.getId());
+
+        log.info("Publisher 발송 완료. campaignId={}, miniAppId={}, subscribers={}, tokens={}",
+                campaign.getId(), miniApp.getId(), stats.subscriberCount(), stats.tokenCount());
+
+        return new PublisherSendNotificationResponse(
+                campaign.getId(),
+                stats.tokenCount(),
+                stats.subscriberCount());
+    }
+
+    /**
+     * 특정 미니앱의 활성 구독자에게 fan-out.
+     * NotificationInbox row 생성 + FCM 발송. 페이지 단위 (chunk=1000).
+     */
+    protected FanOutStats fanOutToSubscribers(NotificationCampaign campaign, Long miniAppId) {
+        int page = 0;
+        int chunkSize = 1000;
+        long totalSubscribers = 0;
+        long totalTokens = 0;
+        Map<String, String> data = buildFcmData(campaign);
+
+        while (true) {
+            List<MiniAppSubscription> subscriptions = subscriptionRepository
+                    .findActiveSubscribersOfMiniApp(miniAppId, PageRequest.of(page, chunkSize));
+            if (subscriptions.isEmpty()) break;
+
+            List<NotificationInbox> inboxes = subscriptions.stream()
+                    .map(s -> NotificationInbox.builder()
+                            .user(s.getUser())
+                            .campaign(campaign)
+                            .build())
+                    .collect(Collectors.toList());
+            inboxRepository.saveAll(inboxes);
+
+            List<String> tokens = subscriptions.stream()
+                    .flatMap(s -> userFcmTokenRepository.findTokensByUserId(s.getUser().getId()).stream())
+                    .collect(Collectors.toList());
+
+            totalSubscribers += subscriptions.size();
+            totalTokens += tokens.size();
+
+            if (!tokens.isEmpty()) {
+                fcmService.sendMulticastWithData(tokens, campaign.getTitle(), campaign.getBody(), data);
+            }
+
+            if (subscriptions.size() < chunkSize) break;
+            page++;
+        }
+        return new FanOutStats(totalSubscribers, totalTokens);
+    }
+
+    private record FanOutStats(long subscriberCount, long tokenCount) {}
 
     private Map<String, String> buildFcmData(NotificationCampaign campaign) {
         Map<String, String> data = new HashMap<>();

--- a/src/main/java/com/union/union/domain/publisher/controller/PublisherApiKeyController.java
+++ b/src/main/java/com/union/union/domain/publisher/controller/PublisherApiKeyController.java
@@ -1,0 +1,61 @@
+package com.union.union.domain.publisher.controller;
+
+import com.union.union.domain.publisher.dto.ApiKeyResponseDto;
+import com.union.union.domain.publisher.dto.IssueApiKeyRequestDto;
+import com.union.union.domain.publisher.dto.IssueApiKeyResponseDto;
+import com.union.union.domain.publisher.service.ApiKeyService;
+import com.union.union.global.security.jwt.JwtUserPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/publishers/me/api-keys")
+@RequiredArgsConstructor
+public class PublisherApiKeyController {
+
+    private final ApiKeyService apiKeyService;
+
+    @PostMapping
+    @PreAuthorize("hasRole('PUBLISHER')")
+    public ResponseEntity<IssueApiKeyResponseDto> issue(
+            @Valid @RequestBody IssueApiKeyRequestDto request,
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        ApiKeyService.IssueResult result = apiKeyService.issue(principal.userId(), request.name());
+        return ResponseEntity.ok(new IssueApiKeyResponseDto(
+                result.id(),
+                result.rawKey(),
+                result.keyPrefix(),
+                result.name(),
+                result.scopes(),
+                result.createdAt()
+        ));
+    }
+
+    @GetMapping
+    @PreAuthorize("hasRole('PUBLISHER')")
+    public ResponseEntity<List<ApiKeyResponseDto>> list(
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        List<ApiKeyResponseDto> keys = apiKeyService.list(principal.userId()).stream()
+                .map(ApiKeyResponseDto::from)
+                .toList();
+        return ResponseEntity.ok(keys);
+    }
+
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('PUBLISHER')")
+    public ResponseEntity<Void> revoke(
+            @PathVariable Long id,
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        apiKeyService.revoke(principal.userId(), id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/union/union/domain/publisher/dto/ApiKeyResponseDto.java
+++ b/src/main/java/com/union/union/domain/publisher/dto/ApiKeyResponseDto.java
@@ -1,0 +1,27 @@
+package com.union.union.domain.publisher.dto;
+
+import com.union.union.domain.publisher.entity.ApiKey;
+
+import java.time.LocalDateTime;
+
+public record ApiKeyResponseDto(
+        Long id,
+        String keyPrefix,
+        String name,
+        String scopes,
+        LocalDateTime createdAt,
+        LocalDateTime lastUsedAt,
+        LocalDateTime revokedAt
+) {
+    public static ApiKeyResponseDto from(ApiKey k) {
+        return new ApiKeyResponseDto(
+                k.getId(),
+                k.getKeyPrefix(),
+                k.getName(),
+                k.getScopes(),
+                k.getCreatedAt(),
+                k.getLastUsedAt(),
+                k.getRevokedAt()
+        );
+    }
+}

--- a/src/main/java/com/union/union/domain/publisher/dto/IssueApiKeyRequestDto.java
+++ b/src/main/java/com/union/union/domain/publisher/dto/IssueApiKeyRequestDto.java
@@ -1,0 +1,10 @@
+package com.union.union.domain.publisher.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record IssueApiKeyRequestDto(
+        @NotBlank
+        @Size(max = 100, message = "name 은 최대 100자")
+        String name
+) {}

--- a/src/main/java/com/union/union/domain/publisher/dto/IssueApiKeyResponseDto.java
+++ b/src/main/java/com/union/union/domain/publisher/dto/IssueApiKeyResponseDto.java
@@ -1,0 +1,12 @@
+package com.union.union.domain.publisher.dto;
+
+import java.time.LocalDateTime;
+
+public record IssueApiKeyResponseDto(
+        Long id,
+        String rawKey,
+        String keyPrefix,
+        String name,
+        String scopes,
+        LocalDateTime createdAt
+) {}

--- a/src/main/java/com/union/union/domain/publisher/entity/ApiKey.java
+++ b/src/main/java/com/union/union/domain/publisher/entity/ApiKey.java
@@ -1,0 +1,80 @@
+package com.union.union.domain.publisher.entity;
+
+import com.union.union.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "publisher_api_keys",
+        uniqueConstraints = @UniqueConstraint(name = "uk_publisher_api_keys_key_hash", columnNames = "key_hash"),
+        indexes = {
+                @Index(name = "idx_publisher_api_keys_publisher", columnList = "publisher_id"),
+                @Index(name = "idx_publisher_api_keys_revoked", columnList = "revoked_at")
+        }
+)
+public class ApiKey extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "publisher_id", referencedColumnName = "publisher_id", nullable = false)
+    private Publisher publisher;
+
+    @Column(name = "key_prefix", nullable = false, length = 16)
+    private String keyPrefix;
+
+    @Column(name = "key_hash", nullable = false, unique = true, length = 64)
+    private String keyHash;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(nullable = false, length = 200)
+    private String scopes;
+
+    @Column(name = "last_used_at")
+    private LocalDateTime lastUsedAt;
+
+    @Column(name = "last_used_ip", length = 45)
+    private String lastUsedIp;
+
+    @Column(name = "revoked_at")
+    private LocalDateTime revokedAt;
+
+    @Builder
+    public ApiKey(Publisher publisher, String keyPrefix, String keyHash, String name, String scopes) {
+        this.publisher = publisher;
+        this.keyPrefix = keyPrefix;
+        this.keyHash = keyHash;
+        this.name = name;
+        this.scopes = scopes != null ? scopes : "notifications:send";
+    }
+
+    public boolean isRevoked() {
+        return revokedAt != null;
+    }
+
+    public void revoke() {
+        this.revokedAt = LocalDateTime.now();
+    }
+
+    public void touch(String ip) {
+        this.lastUsedAt = LocalDateTime.now();
+        this.lastUsedIp = ip;
+    }
+
+    public boolean hasScope(String scope) {
+        if (scopes == null || scope == null) return false;
+        for (String s : scopes.split(",")) {
+            if (s.trim().equals(scope)) return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/union/union/domain/publisher/repository/ApiKeyRepository.java
+++ b/src/main/java/com/union/union/domain/publisher/repository/ApiKeyRepository.java
@@ -1,0 +1,19 @@
+package com.union.union.domain.publisher.repository;
+
+import com.union.union.domain.publisher.entity.ApiKey;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface ApiKeyRepository extends JpaRepository<ApiKey, Long> {
+
+    Optional<ApiKey> findByKeyHash(String keyHash);
+
+    List<ApiKey> findByPublisher_PublisherIdOrderByCreatedAtDesc(UUID publisherId);
+
+    Optional<ApiKey> findByIdAndPublisher_PublisherId(Long id, UUID publisherId);
+}

--- a/src/main/java/com/union/union/domain/publisher/service/ApiKeyService.java
+++ b/src/main/java/com/union/union/domain/publisher/service/ApiKeyService.java
@@ -1,0 +1,121 @@
+package com.union.union.domain.publisher.service;
+
+import com.union.union.domain.publisher.entity.ApiKey;
+import com.union.union.domain.publisher.entity.Publisher;
+import com.union.union.domain.publisher.repository.ApiKeyRepository;
+import com.union.union.domain.publisher.repository.PublisherRepository;
+import com.union.union.global.common.exception.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ApiKeyService {
+
+    public static final String SCOPE_NOTIFICATIONS_SEND = "notifications:send";
+    private static final String KEY_PREFIX = "uk_live_";
+    private static final int RAW_BODY_LENGTH = 32;
+    private static final String ALPHABET =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+    private static final SecureRandom RNG = new SecureRandom();
+
+    private final ApiKeyRepository apiKeyRepository;
+    private final PublisherRepository publisherRepository;
+
+    public IssueResult issue(UUID publisherId, String name) {
+        Publisher publisher = publisherRepository.findByPublisherId(publisherId)
+                .orElseThrow(() -> new EntityNotFoundException("Publisher를 찾을 수 없습니다"));
+
+        String rawBody = randomBase62(RAW_BODY_LENGTH);
+        String rawKey = KEY_PREFIX + rawBody;
+        String keyHash = sha256(rawKey);
+        String keyPrefix = rawKey.substring(0, 12);
+
+        ApiKey saved = apiKeyRepository.save(ApiKey.builder()
+                .publisher(publisher)
+                .keyPrefix(keyPrefix)
+                .keyHash(keyHash)
+                .name(name)
+                .scopes(SCOPE_NOTIFICATIONS_SEND)
+                .build());
+
+        log.info("API Key 발급. publisherId={}, apiKeyId={}, name={}", publisherId, saved.getId(), name);
+        return new IssueResult(
+                saved.getId(),
+                rawKey,
+                keyPrefix,
+                saved.getName(),
+                saved.getScopes(),
+                saved.getCreatedAt());
+    }
+
+    @Transactional(readOnly = true)
+    public List<ApiKey> list(UUID publisherId) {
+        return apiKeyRepository.findByPublisher_PublisherIdOrderByCreatedAtDesc(publisherId);
+    }
+
+    public void revoke(UUID publisherId, Long apiKeyId) {
+        ApiKey key = apiKeyRepository.findByIdAndPublisher_PublisherId(apiKeyId, publisherId)
+                .orElseThrow(() -> new EntityNotFoundException("API Key를 찾을 수 없습니다"));
+        if (!key.isRevoked()) {
+            key.revoke();
+            log.info("API Key 폐기. publisherId={}, apiKeyId={}", publisherId, apiKeyId);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<ApiKey> verify(String rawKey) {
+        if (rawKey == null || !rawKey.startsWith(KEY_PREFIX)) return Optional.empty();
+        String hash = sha256(rawKey);
+        return apiKeyRepository.findByKeyHash(hash).filter(k -> !k.isRevoked());
+    }
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void touchAsync(Long apiKeyId, String ip) {
+        apiKeyRepository.findById(apiKeyId).ifPresent(k -> k.touch(ip));
+    }
+
+    private static String randomBase62(int n) {
+        StringBuilder sb = new StringBuilder(n);
+        for (int i = 0; i < n; i++) {
+            sb.append(ALPHABET.charAt(RNG.nextInt(ALPHABET.length())));
+        }
+        return sb.toString();
+    }
+
+    private static String sha256(String s) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hash = md.digest(s.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder(hash.length * 2);
+            for (byte b : hash) sb.append(String.format("%02x", b));
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 미지원", e);
+        }
+    }
+
+    public record IssueResult(
+            Long id,
+            String rawKey,
+            String keyPrefix,
+            String name,
+            String scopes,
+            java.time.LocalDateTime createdAt
+    ) {}
+}

--- a/src/main/java/com/union/union/domain/subscription/controller/UserSubscriptionController.java
+++ b/src/main/java/com/union/union/domain/subscription/controller/UserSubscriptionController.java
@@ -1,0 +1,58 @@
+package com.union.union.domain.subscription.controller;
+
+import com.union.union.domain.subscription.dto.SubscriptionResponseDto;
+import com.union.union.domain.subscription.dto.UpdatePushEnabledRequestDto;
+import com.union.union.domain.subscription.service.SubscriptionService;
+import com.union.union.global.security.jwt.JwtUserPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class UserSubscriptionController {
+
+    private final SubscriptionService subscriptionService;
+
+    @PostMapping("/api/v1/users/me/miniapps/{appId}/subscription")
+    public ResponseEntity<Void> subscribe(
+            @PathVariable String appId,
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        subscriptionService.subscribeByAppId(principal.userId(), appId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/api/v1/users/me/miniapps/{appId}/subscription")
+    public ResponseEntity<Void> updatePushEnabled(
+            @PathVariable String appId,
+            @Valid @RequestBody UpdatePushEnabledRequestDto request,
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        subscriptionService.setPushEnabled(principal.userId(), appId, request.pushEnabled());
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/api/v1/users/me/miniapps/{appId}/subscription")
+    public ResponseEntity<Void> unsubscribe(
+            @PathVariable String appId,
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        subscriptionService.unsubscribe(principal.userId(), appId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/api/v1/users/me/subscriptions")
+    public ResponseEntity<List<SubscriptionResponseDto>> list(
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        List<SubscriptionResponseDto> subs = subscriptionService.listActiveByUser(principal.userId()).stream()
+                .map(SubscriptionResponseDto::from)
+                .toList();
+        return ResponseEntity.ok(subs);
+    }
+}

--- a/src/main/java/com/union/union/domain/subscription/dto/SubscriptionResponseDto.java
+++ b/src/main/java/com/union/union/domain/subscription/dto/SubscriptionResponseDto.java
@@ -1,0 +1,27 @@
+package com.union.union.domain.subscription.dto;
+
+import com.union.union.domain.subscription.entity.MiniAppSubscription;
+
+import java.time.LocalDateTime;
+
+public record SubscriptionResponseDto(
+        Long id,
+        Long miniAppId,
+        String appId,
+        String miniAppName,
+        String iconUrl,
+        boolean pushEnabled,
+        LocalDateTime subscribedAt
+) {
+    public static SubscriptionResponseDto from(MiniAppSubscription s) {
+        return new SubscriptionResponseDto(
+                s.getId(),
+                s.getMiniApp().getId(),
+                s.getMiniApp().getAppId(),
+                s.getMiniApp().getName(),
+                s.getMiniApp().getIconUrl(),
+                s.isPushEnabled(),
+                s.getSubscribedAt()
+        );
+    }
+}

--- a/src/main/java/com/union/union/domain/subscription/dto/UpdatePushEnabledRequestDto.java
+++ b/src/main/java/com/union/union/domain/subscription/dto/UpdatePushEnabledRequestDto.java
@@ -1,0 +1,7 @@
+package com.union.union.domain.subscription.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdatePushEnabledRequestDto(
+        @NotNull Boolean pushEnabled
+) {}

--- a/src/main/java/com/union/union/domain/subscription/entity/MiniAppSubscription.java
+++ b/src/main/java/com/union/union/domain/subscription/entity/MiniAppSubscription.java
@@ -1,0 +1,76 @@
+package com.union.union.domain.subscription.entity;
+
+import com.union.union.domain.miniapp.entity.MiniApp;
+import com.union.union.domain.user.entity.User;
+import com.union.union.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "mini_app_subscriptions",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_mini_app_subscriptions_user_app",
+                columnNames = {"user_id", "mini_app_id"}
+        ),
+        indexes = {
+                @Index(name = "idx_mini_app_subscriptions_app_push",
+                        columnList = "mini_app_id, push_enabled, unsubscribed_at"),
+                @Index(name = "idx_mini_app_subscriptions_user",
+                        columnList = "user_id")
+        }
+)
+public class MiniAppSubscription extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mini_app_id", nullable = false)
+    private MiniApp miniApp;
+
+    @Column(name = "subscribed_at", nullable = false)
+    private LocalDateTime subscribedAt;
+
+    @Column(name = "push_enabled", nullable = false)
+    private boolean pushEnabled;
+
+    @Column(name = "unsubscribed_at")
+    private LocalDateTime unsubscribedAt;
+
+    @Builder
+    public MiniAppSubscription(User user, MiniApp miniApp) {
+        this.user = user;
+        this.miniApp = miniApp;
+        this.subscribedAt = LocalDateTime.now();
+        this.pushEnabled = true;
+    }
+
+    public boolean isActive() {
+        return unsubscribedAt == null;
+    }
+
+    public void reactivate() {
+        this.unsubscribedAt = null;
+        this.pushEnabled = true;
+        this.subscribedAt = LocalDateTime.now();
+    }
+
+    public void setPushEnabled(boolean enabled) {
+        this.pushEnabled = enabled;
+    }
+
+    public void unsubscribe() {
+        this.unsubscribedAt = LocalDateTime.now();
+        this.pushEnabled = false;
+    }
+}

--- a/src/main/java/com/union/union/domain/subscription/repository/MiniAppSubscriptionRepository.java
+++ b/src/main/java/com/union/union/domain/subscription/repository/MiniAppSubscriptionRepository.java
@@ -1,0 +1,37 @@
+package com.union.union.domain.subscription.repository;
+
+import com.union.union.domain.subscription.entity.MiniAppSubscription;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface MiniAppSubscriptionRepository extends JpaRepository<MiniAppSubscription, Long> {
+
+    Optional<MiniAppSubscription> findByUser_IdAndMiniApp_Id(UUID userId, Long miniAppId);
+
+    @Query("SELECT s FROM MiniAppSubscription s " +
+            "JOIN FETCH s.miniApp m " +
+            "WHERE s.user.id = :userId AND s.unsubscribedAt IS NULL " +
+            "ORDER BY s.subscribedAt DESC")
+    List<MiniAppSubscription> findActiveByUser(@Param("userId") UUID userId);
+
+    @Query("SELECT s FROM MiniAppSubscription s " +
+            "WHERE s.miniApp.id = :miniAppId " +
+            "AND s.pushEnabled = true " +
+            "AND s.unsubscribedAt IS NULL")
+    List<MiniAppSubscription> findActiveSubscribersOfMiniApp(
+            @Param("miniAppId") Long miniAppId, Pageable pageable);
+
+    @Query("SELECT COUNT(s) FROM MiniAppSubscription s " +
+            "WHERE s.miniApp.id = :miniAppId " +
+            "AND s.pushEnabled = true " +
+            "AND s.unsubscribedAt IS NULL")
+    long countActiveSubscribersOfMiniApp(@Param("miniAppId") Long miniAppId);
+}

--- a/src/main/java/com/union/union/domain/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/union/union/domain/subscription/service/SubscriptionService.java
@@ -1,0 +1,99 @@
+package com.union.union.domain.subscription.service;
+
+import com.union.union.domain.miniapp.entity.MiniApp;
+import com.union.union.domain.miniapp.repository.MiniAppRepository;
+import com.union.union.domain.subscription.entity.MiniAppSubscription;
+import com.union.union.domain.subscription.repository.MiniAppSubscriptionRepository;
+import com.union.union.domain.user.entity.User;
+import com.union.union.domain.user.repository.UserRepository;
+import com.union.union.global.common.exception.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SubscriptionService {
+
+    private final MiniAppSubscriptionRepository subscriptionRepository;
+    private final MiniAppRepository miniAppRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 미니앱 실행 시 자동 구독. 이미 활성 구독이 있으면 no-op,
+     * 폐기된 구독이 있으면 재활성화, 없으면 신규 생성.
+     */
+    public void autoSubscribe(UUID userId, Long miniAppId) {
+        subscriptionRepository.findByUser_IdAndMiniApp_Id(userId, miniAppId)
+                .ifPresentOrElse(
+                        existing -> {
+                            if (!existing.isActive()) {
+                                existing.reactivate();
+                                log.info("미니앱 구독 재활성화. userId={}, miniAppId={}", userId, miniAppId);
+                            }
+                        },
+                        () -> {
+                            User user = userRepository.findById(userId)
+                                    .orElseThrow(() -> new EntityNotFoundException("User를 찾을 수 없습니다"));
+                            MiniApp miniApp = miniAppRepository.findById(miniAppId)
+                                    .orElseThrow(() -> new EntityNotFoundException("MiniApp을 찾을 수 없습니다"));
+                            subscriptionRepository.save(MiniAppSubscription.builder()
+                                    .user(user)
+                                    .miniApp(miniApp)
+                                    .build());
+                            log.info("미니앱 신규 구독. userId={}, miniAppId={}", userId, miniAppId);
+                        }
+                );
+    }
+
+    public void subscribeByAppId(UUID userId, String appId) {
+        MiniApp miniApp = miniAppRepository.findByAppId(appId)
+                .orElseThrow(() -> new EntityNotFoundException("MiniApp을 찾을 수 없습니다. appId=" + appId));
+        autoSubscribe(userId, miniApp.getId());
+    }
+
+    public void setPushEnabled(UUID userId, String appId, boolean enabled) {
+        MiniApp miniApp = miniAppRepository.findByAppId(appId)
+                .orElseThrow(() -> new EntityNotFoundException("MiniApp을 찾을 수 없습니다. appId=" + appId));
+        MiniAppSubscription subscription = subscriptionRepository
+                .findByUser_IdAndMiniApp_Id(userId, miniApp.getId())
+                .orElseThrow(() -> new EntityNotFoundException("구독을 찾을 수 없습니다"));
+        if (enabled && !subscription.isActive()) {
+            subscription.reactivate();
+        }
+        subscription.setPushEnabled(enabled);
+        log.info("푸시 토글. userId={}, appId={}, enabled={}", userId, appId, enabled);
+    }
+
+    public void unsubscribe(UUID userId, String appId) {
+        MiniApp miniApp = miniAppRepository.findByAppId(appId)
+                .orElseThrow(() -> new EntityNotFoundException("MiniApp을 찾을 수 없습니다. appId=" + appId));
+        subscriptionRepository.findByUser_IdAndMiniApp_Id(userId, miniApp.getId())
+                .ifPresent(s -> {
+                    s.unsubscribe();
+                    log.info("미니앱 구독 해지. userId={}, appId={}", userId, appId);
+                });
+    }
+
+    @Transactional(readOnly = true)
+    public List<MiniAppSubscription> listActiveByUser(UUID userId) {
+        return subscriptionRepository.findActiveByUser(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public List<MiniAppSubscription> listActiveSubscribers(Long miniAppId, Pageable pageable) {
+        return subscriptionRepository.findActiveSubscribersOfMiniApp(miniAppId, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public long countActiveSubscribers(Long miniAppId) {
+        return subscriptionRepository.countActiveSubscribersOfMiniApp(miniAppId);
+    }
+}

--- a/src/main/java/com/union/union/global/security/apikey/ApiKeyAuthenticationFilter.java
+++ b/src/main/java/com/union/union/global/security/apikey/ApiKeyAuthenticationFilter.java
@@ -1,0 +1,81 @@
+package com.union.union.global.security.apikey;
+
+import com.union.union.domain.publisher.entity.ApiKey;
+import com.union.union.domain.publisher.service.ApiKeyService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
+
+    public static final String HEADER = "X-Union-Api-Key";
+    public static final String ROLE_PUBLISHER_API_KEY = "ROLE_PUBLISHER_API_KEY";
+    public static final String SCOPE_PREFIX = "SCOPE_";
+
+    private final ApiKeyService apiKeyService;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        String raw = request.getHeader(HEADER);
+
+        if (StringUtils.hasText(raw)) {
+            Optional<ApiKey> verified = apiKeyService.verify(raw);
+            if (verified.isPresent()) {
+                ApiKey apiKey = verified.get();
+                UUID publisherId = apiKey.getPublisher().getPublisherId();
+
+                List<GrantedAuthority> authorities = new ArrayList<>();
+                authorities.add(new SimpleGrantedAuthority(ROLE_PUBLISHER_API_KEY));
+                for (String scope : apiKey.getScopes().split(",")) {
+                    String trimmed = scope.trim();
+                    if (!trimmed.isEmpty()) {
+                        authorities.add(new SimpleGrantedAuthority(SCOPE_PREFIX + trimmed));
+                    }
+                }
+
+                PublisherApiKeyPrincipal principal = new PublisherApiKeyPrincipal(publisherId, apiKey.getId());
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(principal, null, authorities);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+                apiKeyService.touchAsync(apiKey.getId(), extractIp(request));
+                log.debug("API Key 인증 성공. publisherId={}, apiKeyId={}", publisherId, apiKey.getId());
+            } else {
+                log.debug("API Key 인증 실패. prefix={}", raw.length() > 12 ? raw.substring(0, 12) : raw);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractIp(HttpServletRequest request) {
+        String forwarded = request.getHeader("X-Forwarded-For");
+        if (StringUtils.hasText(forwarded)) {
+            return forwarded.split(",")[0].trim();
+        }
+        return request.getRemoteAddr();
+    }
+}

--- a/src/main/java/com/union/union/global/security/apikey/PublisherApiKeyPrincipal.java
+++ b/src/main/java/com/union/union/global/security/apikey/PublisherApiKeyPrincipal.java
@@ -1,0 +1,8 @@
+package com.union.union.global.security.apikey;
+
+import java.util.UUID;
+
+public record PublisherApiKeyPrincipal(
+        UUID publisherId,
+        Long apiKeyId
+) {}

--- a/src/main/java/com/union/union/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/union/union/global/security/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.union.union.global.security.config;
 
+import com.union.union.global.security.apikey.ApiKeyAuthenticationFilter;
 import com.union.union.global.security.jwt.JwtAuthenticationFilter;
 import com.union.union.global.security.ratelimit.RateLimitFilter;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,7 @@ import java.util.List;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final ApiKeyAuthenticationFilter apiKeyAuthenticationFilter;
     private final RateLimitFilter rateLimitFilter;
     private final JwtAuthenticationEntryPoint authenticationEntryPoint;
     private final JwtAccessDeniedHandler accessDeniedHandler;
@@ -97,11 +99,28 @@ public class SecurityConfig {
                 .requestMatchers("/notifications/inbox").authenticated()
                 .requestMatchers("/notifications/unread-count").authenticated()
 
+                // Publisher 알림 발송 (API Key 인증)
+                .requestMatchers(HttpMethod.POST, "/api/v1/publishers/notifications")
+                    .hasAuthority("SCOPE_notifications:send")
+
+                // Publisher 알림 발송 (대시보드 JWT 인증, 테스트용)
+                .requestMatchers(HttpMethod.POST, "/api/v1/publishers/me/notifications")
+                    .hasRole("PUBLISHER")
+
+                // Publisher API Key 관리 (JWT 인증, PUBLISHER 권한)
+                .requestMatchers("/api/v1/publishers/me/api-keys/**").hasRole("PUBLISHER")
+                .requestMatchers("/api/v1/publishers/me/api-keys").hasRole("PUBLISHER")
+
+                // 사용자 미니앱 구독 (JWT 인증)
+                .requestMatchers("/api/v1/users/me/miniapps/**").authenticated()
+                .requestMatchers("/api/v1/users/me/subscriptions").authenticated()
+
                 // All other endpoints require authentication
                 .anyRequest().authenticated()
             )
             .addFilterBefore(rateLimitFilter, UsernamePasswordAuthenticationFilter.class)
-            .addFilterAfter(jwtAuthenticationFilter, RateLimitFilter.class);
+            .addFilterAfter(apiKeyAuthenticationFilter, RateLimitFilter.class)
+            .addFilterAfter(jwtAuthenticationFilter, ApiKeyAuthenticationFilter.class);
 
         return http.build();
     }


### PR DESCRIPTION
## Summary

Publisher 백엔드 서버가 Union iOS 미니앱 구독자에게 푸시 알림을 발송할 수 있도록 API Key 인증 + 미니앱 구독 모델을 도입했습니다.

### 핵심 흐름
```
[Publisher 백엔드] --X-Union-Api-Key--> POST /api/v1/publishers/notifications
   → ApiKeyAuthenticationFilter (JWT 필터와 병렬 동작)
   → 미니앱 소유 검증 (WorkspaceAuthorizationService.validateMembership)
   → NotificationCampaign 저장 (senderType=MINIAPP)
   → MiniAppSubscription where pushEnabled=true and unsubscribed_at IS NULL → chunk(1000) 페이징
   → 기존 FcmService.sendMulticastWithData (재사용)
```

### 주요 변경
- **ApiKey 도메인** — `uk_live_<base62 32>` 포맷, SHA-256 해시 저장, 발급 직후 1회만 raw 노출
- **ApiKeyAuthenticationFilter** — `X-Union-Api-Key` 헤더, `RateLimitFilter` 뒤 + `JwtAuthenticationFilter` 앞 위치
- **MiniAppSubscription** — 미니앱 첫 실행(`MiniAppService.getLaunchUrl`)에서 자동 구독, 사용자 push toggle/해지 가능
- **PublisherNotificationController** — API Key 경로 + Dashboard JWT 경로 (테스트용)
- **NotificationService.sendByPublisher / fanOutToSubscribers** — 기존 캠페인/인박스/FCM 인프라 그대로 재사용
- **DTO에 appId 노출** — `MiniAppResponseDto`, `TestBundleResponseDto`에 `appId` 추가 (iOS 알림 모듈이 자기 미니앱 식별에 사용)

### 신규 엔드포인트
| Method | Path | 인증 |
|---|---|---|
| POST | `/api/v1/publishers/notifications` | API Key (`SCOPE_notifications:send`) |
| POST | `/api/v1/publishers/me/notifications` | JWT (`ROLE_PUBLISHER`, dashboard 테스트용) |
| POST/GET/DELETE | `/api/v1/publishers/me/api-keys[/{id}]` | JWT |
| POST/PATCH/DELETE | `/api/v1/users/me/miniapps/{appId}/subscription` | JWT |
| GET | `/api/v1/users/me/subscriptions` | JWT |

## Test plan
- [ ] Dashboard JWT로 `POST /api/v1/publishers/me/api-keys` → raw key 1회 수신
- [ ] `curl -X POST .../v1/publishers/notifications -H "X-Union-Api-Key: ..."` → 200 + `{campaignId, sentTokenCount}`
- [ ] DB 확인: `notification_campaign`(senderType=MINIAPP) + `notification_inbox` row 생성 + `publisher_api_keys.last_used_at` 갱신
- [ ] 타 publisher 미니앱 발송 시 → `403 UnauthorizedAccessException`
- [ ] 폐기된 API Key 재사용 → 401
- [ ] iOS 실기기에서 권한 → 토큰 등록 → 발송 → 수신 확인 (별도 iOS PR 머지 후)

## 인프라 파일 (별도 PR 예정)
`.dockerignore`, `Dockerfile`, `INFRA.md`, `cloud-run.yaml`, `cors.json`, `GcsConfig.java` 수정은 Cloud Run 배포용으로 의도된 별도 변경이라 이 PR에 포함하지 않았습니다.