### PR TITLE
feat(miniapp): appId 필수화 + Dashboard 등록 폼 연동 + Cloud Run 배포 정의

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.gradle
+build
+out
+.idea
+.vscode
+.claude
+*.iml
+*.log
+dump.rdb
+.env
+.env.example
+union-storage-key.json
+src/main/resources/application-local.yml
+docs
+README.md
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ src/main/resources/application-local.yml
 *.log
 *-key.json
 dump.rdb
+# Cloud Run 배포 정의 — prod secret 평문 포함, 로컬에서만 보관
+cloud-run.yaml
+# GCP 인프라 운영 문서 — project ID/VPC 내부 정보 포함, 로컬에서만 보관
+INFRA.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1.6
+
+FROM eclipse-temurin:17-jdk AS build
+WORKDIR /workspace
+COPY gradlew settings.gradle build.gradle ./
+COPY gradle gradle
+RUN chmod +x gradlew && ./gradlew --no-daemon dependencies > /dev/null 2>&1 || true
+COPY src src
+RUN ./gradlew --no-daemon clean bootJar -x test
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+COPY --from=build /workspace/build/libs/*.jar /app/app.jar
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=70 -XX:+UseG1GC -Djava.security.egd=file:/dev/./urandom"
+ENV SERVER_PORT=8080
+EXPOSE 8080
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -Dserver.port=${PORT:-8080} -jar /app/app.jar"]

--- a/cors.json
+++ b/cors.json
@@ -1,0 +1,11 @@
+[
+  {
+    "origin": [
+      "https://union-phi.vercel.app",
+      "http://localhost:3000"
+    ],
+    "method": ["PUT", "GET"],
+    "responseHeader": ["Content-Type"],
+    "maxAgeSeconds": 3600
+  }
+]

--- a/src/main/java/com/union/union/domain/miniapp/controller/MiniAppController.java
+++ b/src/main/java/com/union/union/domain/miniapp/controller/MiniAppController.java
@@ -42,6 +42,19 @@ public class MiniAppController {
         return ResponseEntity.ok(response);
     }
 
+    /**
+     * appId 사용 가능 여부 조회. Dashboard 등록 폼의 실시간 중복 체크에서 호출.
+     * 등록 직전 race condition 은 register() 의 unique 제약이 최종 보루.
+     */
+    @GetMapping("/check-app-id")
+    @PreAuthorize("hasRole('PUBLISHER')")
+    public ResponseEntity<Map<String, Boolean>> checkAppIdAvailable(
+            @RequestParam("appId") String appId
+    ) {
+        boolean available = miniAppService.isAppIdAvailable(appId);
+        return ResponseEntity.ok(Map.of("available", available));
+    }
+
     @PostMapping
     @PreAuthorize("hasRole('PUBLISHER')")
     public ResponseEntity<MiniAppResponseDto> register(

--- a/src/main/java/com/union/union/domain/miniapp/dto/MiniAppRegisterRequestDto.java
+++ b/src/main/java/com/union/union/domain/miniapp/dto/MiniAppRegisterRequestDto.java
@@ -3,6 +3,7 @@ package com.union.union.domain.miniapp.dto;
 import com.union.union.domain.miniapp.entity.PermissionScope;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 import java.util.List;
@@ -25,6 +26,12 @@ public record MiniAppRegisterRequestDto(
     @NotNull(message = "카테고리 ID는 필수입니다")
     Long categoryId,
 
+    @NotBlank(message = "appId는 필수입니다")
+    @Size(max = 100, message = "appId는 100자 이내여야 합니다")
+    @Pattern(
+        regexp = "^[a-z][a-z0-9]*(\\.[a-z][a-z0-9-]*)+$",
+        message = "appId는 reverse-domain 형식이어야 합니다 (예: com.union.sample-app)"
+    )
     String appId,
 
     @Size(max = 10, message = "키워드는 최대 10개까지 입력 가능합니다")

--- a/src/main/java/com/union/union/domain/miniapp/entity/MiniApp.java
+++ b/src/main/java/com/union/union/domain/miniapp/entity/MiniApp.java
@@ -45,10 +45,10 @@ public class MiniApp extends BaseEntity {
 
     /**
      * 미니앱 식별자 (reverse-domain, e.g. "com.union.soccer").
-     * union.config.json 의 appId 와 동일. Analytics 이벤트 매핑 키.
-     * 기존 앱은 null 허용, 신규 앱은 non-null.
+     * union.config.json 의 appId 와 동일. Analytics 이벤트 매핑 키 + 알림 발송 targetAppId.
+     * 모든 신규/기존 앱에 필수 (레거시 row 는 com.union.legacy-{id} placeholder 로 마이그레이션됨).
      */
-    @Column(name = "app_id", unique = true, length = 100)
+    @Column(name = "app_id", unique = true, length = 100, nullable = false)
     private String appId;
 
     @Column(name = "searchable_name", length = 300)

--- a/src/main/java/com/union/union/domain/miniapp/repository/MiniAppRepository.java
+++ b/src/main/java/com/union/union/domain/miniapp/repository/MiniAppRepository.java
@@ -102,4 +102,10 @@ public interface MiniAppRepository extends JpaRepository<MiniApp, Long> {
      * Analytics 이벤트 수신 시 APPROVED 앱 여부 검증에 사용.
      */
     boolean existsByAppIdAndStatus(String appId, MiniAppStatus status);
+
+    /**
+     * appId 중복 여부 확인 (count 쿼리, 경량).
+     * Dashboard 등록 폼의 실시간 중복 체크에 사용.
+     */
+    boolean existsByAppId(String appId);
 }

--- a/src/main/java/com/union/union/domain/miniapp/service/MiniAppService.java
+++ b/src/main/java/com/union/union/domain/miniapp/service/MiniAppService.java
@@ -54,6 +54,14 @@ public class MiniAppService {
     private final MiniAppCacheService miniAppCacheService;
     private final SubscriptionService subscriptionService;
 
+    /**
+     * appId 중복 여부 확인. Dashboard 등록 폼의 실시간 체크에서 호출.
+     * race condition 은 등록 시 unique 제약이 최종 보루.
+     */
+    public boolean isAppIdAvailable(String appId) {
+        return !miniAppRepository.existsByAppId(appId);
+    }
+
     @Transactional
     @CacheEvict(value = "miniApps", allEntries = true)
     public MiniAppResponseDto register(MiniAppRegisterRequestDto request, UUID publisherId) {
@@ -64,6 +72,10 @@ public class MiniAppService {
 
         MiniAppCategory category = miniAppCategoryRepository.findById(request.categoryId())
                 .orElseThrow(() -> new EntityNotFoundException("카테고리를 찾을 수 없습니다"));
+
+        if (miniAppRepository.existsByAppId(request.appId())) {
+            throw new IllegalArgumentException("이미 사용 중인 appId 입니다: " + request.appId());
+        }
 
         String tags = (request.keywords() != null && !request.keywords().isEmpty())
                 ? String.join(",", request.keywords())

--- a/src/main/java/com/union/union/global/config/GcsConfig.java
+++ b/src/main/java/com/union/union/global/config/GcsConfig.java
@@ -13,12 +13,14 @@ import java.io.IOException;
 @Configuration
 public class GcsConfig {
 
-    @Value("${spring.cloud.gcp.storage.credentials.location}")
+    @Value("${spring.cloud.gcp.storage.credentials.location:}")
     private Resource credentialsLocation;
 
     @Bean
     public Storage storage() throws IOException {
-        GoogleCredentials credentials = GoogleCredentials.fromStream(credentialsLocation.getInputStream());
+        GoogleCredentials credentials = (credentialsLocation != null && credentialsLocation.exists())
+                ? GoogleCredentials.fromStream(credentialsLocation.getInputStream())
+                : GoogleCredentials.getApplicationDefault();
         return StorageOptions.newBuilder()
                 .setCredentials(credentials)
                 .build()


### PR DESCRIPTION
## Summary
- Dashboard 등록 폼이 보낼 `appId` (reverse-domain) 를 Spring 에서 필수 + unique 로 강제하고, 실시간 중복 체크용 read 엔드포인트를 추가했습니다.
- GCP Cloud Run 배포 인프라(Multi-stage Dockerfile, .dockerignore, GCS bucket CORS, ADC fallback) 를 함께 포함합니다.
- prod secret 평문이 들어있는 `cloud-run.yaml` 과 GCP 내부 정보를 담은 `INFRA.md` 는 `.gitignore` 처리 (로컬에서만 관리).

## Changes
**appId 필수화 & 중복 체크**
- `MiniApp` 엔티티: `app_id` 컬럼 `nullable=false` (마이그레이션 완료)
- `MiniAppRegisterRequestDto`: `@NotBlank` + `@Size(max=100)` + `@Pattern(reverse-domain)`
- `MiniAppService.register`: 사전 중복 체크 (race 는 unique 제약이 최종 보루)
- `MiniAppService.isAppIdAvailable` + `MiniAppRepository.existsByAppId`
- `MiniAppController` `GET /mini-apps/check-app-id?appId=...` (PUBLISHER 권한)

**GCP 배포 인프라**
- `Dockerfile` (multi-stage temurin-17 JDK→JRE)
- `.dockerignore` (.env / key json / application-local.yml 제외)
- `cors.json` (GCS bucket CORS for signed URL PUT)
- `GcsConfig`: `credentials.location` 비어있으면 `GoogleCredentials.getApplicationDefault()` 로 fallback → Cloud Run SA 자동 적용
- `.gitignore`: `cloud-run.yaml`, `INFRA.md` 추가

## Test plan
- [x] `./gradlew compileJava` 통과
- [ ] develop merge 후 Cloud Run 에 v8 태그로 재배포
- [ ] Dashboard 폼에서 `POST /mini-apps` 가 400 (formats invalid) / 200 (success) / 409-ish (duplicate) 정상 분기 확인
- [ ] `GET /mini-apps/check-app-id?appId=com.union.sample-app` → `{ "available": true|false }` 확인