### PR TITLE
feat(user,report): 프로필 수정/탈퇴 API 및 신고 어드민 API 구현

### DIFF
--- a/src/main/java/com/union/union/domain/report/controller/AdminReportController.java
+++ b/src/main/java/com/union/union/domain/report/controller/AdminReportController.java
@@ -1,0 +1,45 @@
+package com.union.union.domain.report.controller;
+
+import com.union.union.domain.report.dto.AdminReportResponseDto;
+import com.union.union.domain.report.dto.ProcessReportRequestDto;
+import com.union.union.domain.report.entity.ReportStatus;
+import com.union.union.domain.report.entity.ReportTargetType;
+import com.union.union.domain.report.service.AdminReportService;
+import com.union.union.global.security.jwt.JwtUserPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/admin/reports")
+@RequiredArgsConstructor
+public class AdminReportController {
+
+    private final AdminReportService adminReportService;
+
+    @GetMapping
+    public ResponseEntity<Page<AdminReportResponseDto>> getReports(
+            @RequestParam(required = false) ReportStatus status,
+            @RequestParam(required = false) ReportTargetType targetType,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(adminReportService.getReports(status, targetType, pageable));
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<AdminReportResponseDto> processReport(
+            @PathVariable UUID id,
+            @Valid @RequestBody ProcessReportRequestDto request,
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        return ResponseEntity.ok(adminReportService.processReport(id, principal.userId(), request));
+    }
+}

--- a/src/main/java/com/union/union/domain/report/dto/AdminReportResponseDto.java
+++ b/src/main/java/com/union/union/domain/report/dto/AdminReportResponseDto.java
@@ -1,0 +1,45 @@
+package com.union.union.domain.report.dto;
+
+import com.union.union.domain.report.entity.Report;
+import com.union.union.domain.report.entity.ReportReason;
+import com.union.union.domain.report.entity.ReportStatus;
+import com.union.union.domain.report.entity.ReportTargetType;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record AdminReportResponseDto(
+        UUID id,
+        UUID reporterId,
+        String reporterNickname,
+        ReportTargetType targetType,
+        Long targetMiniAppId,
+        UUID targetReviewId,
+        UUID reportedUserId,
+        ReportReason reason,
+        String detail,
+        ReportStatus status,
+        String actionTaken,
+        UUID reviewedBy,
+        LocalDateTime reviewedAt,
+        LocalDateTime createdAt
+) {
+    public static AdminReportResponseDto from(Report report) {
+        return new AdminReportResponseDto(
+                report.getId(),
+                report.getReporter().getId(),
+                report.getReporter().getNickname(),
+                report.getTargetType(),
+                report.getTargetMiniAppId(),
+                report.getTargetReviewId(),
+                report.getReportedUserId(),
+                report.getReason(),
+                report.getDetail(),
+                report.getStatus(),
+                report.getActionTaken(),
+                report.getReviewedBy(),
+                report.getReviewedAt(),
+                report.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/union/union/domain/report/dto/ProcessReportRequestDto.java
+++ b/src/main/java/com/union/union/domain/report/dto/ProcessReportRequestDto.java
@@ -1,0 +1,10 @@
+package com.union.union.domain.report.dto;
+
+import com.union.union.domain.report.entity.ReportStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record ProcessReportRequestDto(
+        @NotNull
+        ReportStatus status,
+        String actionTaken
+) {}

--- a/src/main/java/com/union/union/domain/report/entity/Report.java
+++ b/src/main/java/com/union/union/domain/report/entity/Report.java
@@ -72,4 +72,11 @@ public class Report extends BaseEntity {
         this.status = ReportStatus.PENDING;
         this.actionTaken = "NONE";
     }
+
+    public void process(UUID adminId, ReportStatus newStatus, String actionTaken) {
+        this.status = newStatus;
+        this.reviewedBy = adminId;
+        this.reviewedAt = java.time.LocalDateTime.now();
+        if (actionTaken != null) this.actionTaken = actionTaken;
+    }
 }

--- a/src/main/java/com/union/union/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/union/union/domain/report/repository/ReportRepository.java
@@ -3,6 +3,8 @@ package com.union.union.domain.report.repository;
 import com.union.union.domain.report.entity.Report;
 import com.union.union.domain.report.entity.ReportStatus;
 import com.union.union.domain.report.entity.ReportTargetType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -29,5 +31,17 @@ public interface ReportRepository extends JpaRepository<Report, UUID> {
             @Param("miniAppId") Long miniAppId,
             @Param("reviewId") UUID reviewId,
             @Param("reportedUserId") UUID reportedUserId
+    );
+
+    @Query("""
+        SELECT r FROM Report r
+        WHERE (:status IS NULL OR r.status = :status)
+          AND (:targetType IS NULL OR r.targetType = :targetType)
+        ORDER BY r.createdAt DESC
+        """)
+    Page<Report> findWithFilters(
+            @Param("status") ReportStatus status,
+            @Param("targetType") ReportTargetType targetType,
+            Pageable pageable
     );
 }

--- a/src/main/java/com/union/union/domain/report/service/AdminReportService.java
+++ b/src/main/java/com/union/union/domain/report/service/AdminReportService.java
@@ -1,0 +1,42 @@
+package com.union.union.domain.report.service;
+
+import com.union.union.domain.report.dto.AdminReportResponseDto;
+import com.union.union.domain.report.dto.ProcessReportRequestDto;
+import com.union.union.domain.report.entity.Report;
+import com.union.union.domain.report.entity.ReportStatus;
+import com.union.union.domain.report.entity.ReportTargetType;
+import com.union.union.domain.report.repository.ReportRepository;
+import com.union.union.global.common.exception.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminReportService {
+
+    private final ReportRepository reportRepository;
+
+    public Page<AdminReportResponseDto> getReports(ReportStatus status, ReportTargetType targetType, Pageable pageable) {
+        return reportRepository.findWithFilters(status, targetType, pageable)
+                .map(AdminReportResponseDto::from);
+    }
+
+    @Transactional
+    public AdminReportResponseDto processReport(UUID reportId, UUID adminId, ProcessReportRequestDto request) {
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new EntityNotFoundException("신고를 찾을 수 없습니다"));
+
+        report.process(adminId, request.status(), request.actionTaken());
+
+        log.info("신고 처리 완료. reportId={}, status={}, adminId={}", reportId, request.status(), adminId);
+        return AdminReportResponseDto.from(report);
+    }
+}

--- a/src/main/java/com/union/union/domain/user/controller/UserController.java
+++ b/src/main/java/com/union/union/domain/user/controller/UserController.java
@@ -1,8 +1,13 @@
 package com.union.union.domain.user.controller;
 
+import com.union.union.domain.user.dto.ProfileImageUploadUrlRequestDto;
+import com.union.union.domain.user.dto.UpdateNicknameRequestDto;
+import com.union.union.domain.user.dto.UpdateProfileImageRequestDto;
 import com.union.union.domain.user.entity.User;
 import com.union.union.domain.user.service.UserService;
+import com.union.union.global.infra.gcs.dto.GcsSignedUrlResponseDto;
 import com.union.union.global.security.jwt.JwtUserPrincipal;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -23,6 +28,39 @@ public class UserController {
     public ResponseEntity<UserResponse> getMe(@AuthenticationPrincipal JwtUserPrincipal principal) {
         User user = userService.getUser(principal.userId());
         return ResponseEntity.ok(UserResponse.from(user));
+    }
+
+    @PatchMapping("/me")
+    public ResponseEntity<UserResponse> updateNickname(
+            @Valid @RequestBody UpdateNicknameRequestDto request,
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        User user = userService.updateNickname(principal.userId(), request);
+        return ResponseEntity.ok(UserResponse.from(user));
+    }
+
+    @PostMapping("/me/profile-image/upload-url")
+    public ResponseEntity<GcsSignedUrlResponseDto> getProfileImageUploadUrl(
+            @Valid @RequestBody ProfileImageUploadUrlRequestDto request,
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        GcsSignedUrlResponseDto response = userService.getProfileImageUploadUrl(principal.userId(), request);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/me/profile-image")
+    public ResponseEntity<UserResponse> updateProfileImage(
+            @Valid @RequestBody UpdateProfileImageRequestDto request,
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        User user = userService.updateProfileImage(principal.userId(), request);
+        return ResponseEntity.ok(UserResponse.from(user));
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> withdrawMe(@AuthenticationPrincipal JwtUserPrincipal principal) {
+        userService.withdrawMe(principal.userId());
+        return ResponseEntity.noContent().build();
     }
 
     @GetMapping("/{id}")
@@ -47,10 +85,11 @@ public class UserController {
         return ResponseEntity.noContent().build();
     }
 
-    public record UserResponse(UUID id, String email, String nickname, String universityName, boolean isVerified) {
+    public record UserResponse(UUID id, String email, String nickname, String profileImage,
+                               String universityName, boolean isVerified) {
         public static UserResponse from(User user) {
             return new UserResponse(
-                    user.getId(), user.getEmail(), user.getNickname(),
+                    user.getId(), user.getEmail(), user.getNickname(), user.getProfileImage(),
                     user.getUniversityName(), user.isVerified()
             );
         }

--- a/src/main/java/com/union/union/domain/user/dto/ProfileImageUploadUrlRequestDto.java
+++ b/src/main/java/com/union/union/domain/user/dto/ProfileImageUploadUrlRequestDto.java
@@ -1,0 +1,8 @@
+package com.union.union.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ProfileImageUploadUrlRequestDto(
+        @NotBlank
+        String filename
+) {}

--- a/src/main/java/com/union/union/domain/user/dto/UpdateNicknameRequestDto.java
+++ b/src/main/java/com/union/union/domain/user/dto/UpdateNicknameRequestDto.java
@@ -1,0 +1,9 @@
+package com.union.union.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record UpdateNicknameRequestDto(
+        @NotBlank @Size(max = 50)
+        String nickname
+) {}

--- a/src/main/java/com/union/union/domain/user/dto/UpdateProfileImageRequestDto.java
+++ b/src/main/java/com/union/union/domain/user/dto/UpdateProfileImageRequestDto.java
@@ -1,0 +1,8 @@
+package com.union.union.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateProfileImageRequestDto(
+        @NotBlank
+        String imageUrl
+) {}

--- a/src/main/java/com/union/union/domain/user/service/UserService.java
+++ b/src/main/java/com/union/union/domain/user/service/UserService.java
@@ -1,7 +1,13 @@
 package com.union.union.domain.user.service;
 
+import com.union.union.domain.user.dto.ProfileImageUploadUrlRequestDto;
+import com.union.union.domain.user.dto.UpdateNicknameRequestDto;
+import com.union.union.domain.user.dto.UpdateProfileImageRequestDto;
 import com.union.union.domain.user.entity.User;
 import com.union.union.domain.user.repository.UserRepository;
+import com.union.union.global.common.exception.EntityNotFoundException;
+import com.union.union.global.infra.gcs.GcsService;
+import com.union.union.global.infra.gcs.dto.GcsSignedUrlResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,14 +21,40 @@ import java.util.UUID;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final GcsService gcsService;
 
     public User getUser(UUID id) {
         return userRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. id: " + id));
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다. id: " + id));
     }
 
     public List<User> getAllUsers() {
         return userRepository.findAll();
+    }
+
+    @Transactional
+    public User updateNickname(UUID userId, UpdateNicknameRequestDto request) {
+        User user = getUser(userId);
+        user.updateProfile(request.nickname(), null);
+        return user;
+    }
+
+    public GcsSignedUrlResponseDto getProfileImageUploadUrl(UUID userId, ProfileImageUploadUrlRequestDto request) {
+        getUser(userId); // 존재 여부 검증
+        return gcsService.getProfileImageUploadUrl(userId, request.filename());
+    }
+
+    @Transactional
+    public User updateProfileImage(UUID userId, UpdateProfileImageRequestDto request) {
+        User user = getUser(userId);
+        user.updateProfile(null, request.imageUrl());
+        return user;
+    }
+
+    @Transactional
+    public void withdrawMe(UUID userId) {
+        User user = getUser(userId);
+        user.withdraw();
     }
 
     @Transactional

--- a/src/main/java/com/union/union/global/infra/gcs/GcsService.java
+++ b/src/main/java/com/union/union/global/infra/gcs/GcsService.java
@@ -126,6 +126,28 @@ public class GcsService {
     }
 
     /**
+     * 유저 프로필 이미지 업로드용 GCS Signed PUT URL (5분) + 공개 다운로드 URL.
+     * 배너 버킷(public read)의 profiles/{userId}/ 경로에 저장.
+     */
+    public GcsSignedUrlResponseDto getProfileImageUploadUrl(UUID userId, String filename) {
+        String ext = filename.contains(".") ? filename.substring(filename.lastIndexOf('.')) : "";
+        String blobName = String.format("profiles/%s/%s%s", userId, UUID.randomUUID(), ext);
+
+        BlobInfo blobInfo = BlobInfo.newBuilder(bannerBucketName, blobName).build();
+
+        URL signedUrl = storage.signUrl(
+                blobInfo,
+                5,
+                TimeUnit.MINUTES,
+                Storage.SignUrlOption.httpMethod(HttpMethod.PUT),
+                Storage.SignUrlOption.withV4Signature()
+        );
+
+        String publicUrl = "https://storage.googleapis.com/" + bannerBucketName + "/" + blobName;
+        return new GcsSignedUrlResponseDto(signedUrl.toString(), publicUrl);
+    }
+
+    /**
      * CDN Signed URL 조회 (Redis 캐시 → 미스 시 생성)
      */
     public String getCdnDownloadUrl(String objectPath) {


### PR DESCRIPTION
- PATCH /api/v1/users/me — 닉네임 수정
- POST /api/v1/users/me/profile-image/upload-url — GCS Signed URL 발급
- PATCH /api/v1/users/me/profile-image — 프로필 이미지 URL 저장
- DELETE /api/v1/users/me — 회원 탈퇴 (soft delete)
- GET /api/v1/admin/reports — 신고 목록 (status/targetType 필터, 페이징)
- PATCH /api/v1/admin/reports/{id} — 신고 처리 (RESOLVED/DISMISSED)
- GcsService에 profiles/{userId}/ 경로 Signed URL 생성 추가