### PR TITLE
feat(notification): MINIAPP 딥링크 푸시에 miniAppId 동봉

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,20 @@
+# gcloud builds submit 업로드 제외 목록.
+# 빌드에 필요한 것은 gradle wrapper + build/settings.gradle + gradle/ + src/ 뿐이다.
+# 민감 파일(키)·로컬 설정·빌드 산출물은 업로드하지 않는다.
+.git
+.gradle
+build
+out
+.idea
+.vscode
+.claude
+scripts
+*.iml
+*.log
+dump.rdb
+.env
+.env.example
+union-storage-key.json
+src/main/resources/application-local.yml
+docs
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ out/
 src/main/resources/application-local.yml
 *.log
 *-key.json
+service-account*.json
+# FCM 수동 발송 테스트 (로컬 전용 — service account 키/의존성 포함)
+scripts/fcm-test/node_modules/
 dump.rdb
 # Cloud Run 배포 정의 — prod secret 평문 포함, 로컬에서만 보관
 cloud-run.yaml

--- a/src/main/java/com/union/union/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/union/union/domain/notification/service/NotificationService.java
@@ -275,7 +275,15 @@ public class NotificationService {
         data.put("campaignId", String.valueOf(campaign.getId()));
         data.put("category", campaign.getCategory().name());
         data.put("deeplinkType", campaign.getDeeplinkType().name());
-        if (campaign.getTargetAppId() != null) data.put("appId", campaign.getTargetAppId());
+        if (campaign.getTargetAppId() != null) {
+            data.put("appId", campaign.getTargetAppId());
+            // MINIAPP 딥링크는 iOS가 미니앱 launch API(/mini-apps/{Long id}/launch)를 호출해야 하므로,
+            // appId(String) 외에 미니앱 DB id 도 동봉한다. iOS 는 추가 조회 없이 바로 미니앱을 연다.
+            if (campaign.getDeeplinkType() == DeeplinkType.MINIAPP) {
+                miniAppRepository.findByAppId(campaign.getTargetAppId())
+                        .ifPresent(app -> data.put("miniAppId", String.valueOf(app.getId())));
+            }
+        }
         if (campaign.getTargetPath() != null) data.put("path", campaign.getTargetPath());
         if (campaign.getTargetWebUrl() != null) data.put("webUrl", campaign.getTargetWebUrl());
         if (campaign.getTargetInternalRoute() != null) data.put("internalRoute", campaign.getTargetInternalRoute());


### PR DESCRIPTION
## 변경
iOS가 `appId`(String)만으로는 미니앱 launch API(`/mini-apps/{Long id}/launch`)를 호출할 수 없어, MINIAPP 딥링크 알림 payload에 미니앱 DB id(`miniAppId`)를 함께 싣는다.

- `buildFcmData`: `deeplinkType=MINIAPP`일 때 `findByAppId`로 조회해 `miniAppId` 추가
- `.gcloudignore`: Cloud Build 업로드에서 키/로컬설정 제외
- `.gitignore`: FCM 테스트용 service account 키 제외

## iOS 연동
iOS는 이 `miniAppId`로 합성 MiniApp을 만들어 푸시 탭 시 미니앱을 전체화면으로 연다.

## 배포 상태
이미 운영(`union-api:v9`, 리비전 `00012-l8g`)에 반영 + Firebase credential 주입 완료.