### PR TITLE
feat(user,auth): 회원 탈퇴/로그아웃 계정 라이프사이클 하드닝

### DIFF
--- a/src/main/java/com/union/union/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/union/union/domain/auth/controller/AuthController.java
@@ -36,8 +36,11 @@ public class AuthController {
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<Void> logout(@AuthenticationPrincipal JwtUserPrincipal principal) {
-        authService.logout(principal.userId());
+    public ResponseEntity<Void> logout(
+            @RequestBody(required = false) LogoutRequestDto request,
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        authService.logout(principal.userId(), request != null ? request.refreshToken() : null);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/union/union/domain/auth/dto/LogoutRequestDto.java
+++ b/src/main/java/com/union/union/domain/auth/dto/LogoutRequestDto.java
@@ -1,0 +1,10 @@
+package com.union.union.domain.auth.dto;
+
+/**
+ * 로그아웃 요청. refreshToken 이 주어지면 그 토큰(= 해당 기기 세션)만 무효화하고,
+ * 없으면(구버전 클라이언트) 사용자의 모든 refresh 토큰을 무효화한다.
+ */
+public record LogoutRequestDto(
+        String refreshToken
+) {
+}

--- a/src/main/java/com/union/union/domain/auth/service/AuthService.java
+++ b/src/main/java/com/union/union/domain/auth/service/AuthService.java
@@ -85,7 +85,9 @@ public class AuthService {
         return issueTokens(user);
     }
 
-    @Transactional
+    // refresh 거부 시에도 의도된 토큰 무효화(재사용 감지/만료/비활성 계정 revoke)는 보존해야 한다.
+    // InvalidRefreshTokenException(RuntimeException) 으로 인한 롤백을 막아 revoke 가 커밋되게 한다.
+    @Transactional(noRollbackFor = InvalidRefreshTokenException.class)
     public TokenResponseDto refresh(RefreshRequestDto request) {
         RefreshToken storedToken = refreshTokenRepository.findByToken(request.refreshToken())
                 .orElseThrow(() -> new InvalidRefreshTokenException("유효하지 않은 refresh token입니다"));

--- a/src/main/java/com/union/union/domain/auth/service/AuthService.java
+++ b/src/main/java/com/union/union/domain/auth/service/AuthService.java
@@ -102,10 +102,21 @@ public class AuthService {
             throw new InvalidRefreshTokenException("세션이 만료되었습니다. 다시 로그인해주세요.");
         }
 
+        User user = storedToken.getUser();
+
+        // 비활성(탈퇴/정지) 계정은 토큰 재발급 차단.
+        // login() 과 달리 refresh 는 그동안 상태 검사가 없어, 정지된 사용자(suspend() 는 토큰을
+        // revoke 하지 않음)나 탈퇴 직후 race 로 살아남은 토큰으로 access 토큰을 계속 찍어낼 수 있었다.
+        // 이 단일 choke point 에서 막는다(매 요청 DB 조회 없이).
+        if (user.getUserStatus() != User.UserStatus.ACTIVE) {
+            log.warn("비활성 계정의 토큰 갱신 시도 차단. userId={}, status={}", user.getId(), user.getUserStatus());
+            refreshTokenRepository.revokeAllByUserId(user.getId());
+            throw new InvalidRefreshTokenException("비활성화된 계정입니다. 다시 로그인해주세요.");
+        }
+
         // Rotation: 기존 토큰 무효화
         storedToken.revoke();
 
-        User user = storedToken.getUser();
         log.info("토큰 갱신. userId={}", user.getId());
         return issueTokens(user);
     }

--- a/src/main/java/com/union/union/domain/auth/service/AuthService.java
+++ b/src/main/java/com/union/union/domain/auth/service/AuthService.java
@@ -122,11 +122,24 @@ public class AuthService {
     }
 
     @Transactional
-    public void logout(UUID userId) {
+    public void logout(UUID userId, String refreshToken) {
         userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다"));
-        refreshTokenRepository.revokeAllByUserId(userId);
-        log.info("로그아웃. userId={}", userId);
+
+        if (refreshToken != null && !refreshToken.isBlank()) {
+            // 해당 기기의 refresh 토큰만 무효화한다.
+            // - 다른 기기 세션을 끊지 않는다(기기 단위 로그아웃)
+            // - 로그아웃 직후 재로그인이 발생해도 새 세션의 토큰은 건드리지 않는다(전체 무효화 race 방지)
+            // 본인 토큰일 때만 처리하며, 일치하지 않으면 무시한다(전체 무효화 폴백으로 빠지지 않음).
+            refreshTokenRepository.findByToken(refreshToken)
+                    .filter(rt -> rt.getUser().getId().equals(userId))
+                    .ifPresent(RefreshToken::revoke);
+            log.info("로그아웃(기기 단위). userId={}", userId);
+        } else {
+            // 토큰 미제공(구버전 클라이언트) → 전체 세션 무효화 폴백
+            refreshTokenRepository.revokeAllByUserId(userId);
+            log.info("로그아웃(전체). userId={}", userId);
+        }
     }
 
     private TokenResponseDto issueTokens(User user) {

--- a/src/main/java/com/union/union/domain/notification/repository/UserFcmTokenRepository.java
+++ b/src/main/java/com/union/union/domain/notification/repository/UserFcmTokenRepository.java
@@ -28,4 +28,12 @@ public interface UserFcmTokenRepository extends JpaRepository<UserFcmToken, Long
     @Modifying
     @Query("DELETE FROM UserFcmToken t WHERE t.user.id = :userId AND t.deviceId = :deviceId")
     void deleteByUserIdAndDeviceId(@Param("userId") UUID userId, @Param("deviceId") String deviceId);
+
+    /**
+     * 사용자의 모든 FCM 토큰을 일괄 삭제한다. 회원 탈퇴 시 호출 — 탈퇴한 기기로 푸시가 계속 가지 않도록.
+     * @return 삭제된 행 수
+     */
+    @Modifying
+    @Query("DELETE FROM UserFcmToken t WHERE t.user.id = :userId")
+    int deleteAllByUserId(@Param("userId") UUID userId);
 }

--- a/src/main/java/com/union/union/domain/subscription/repository/MiniAppSubscriptionRepository.java
+++ b/src/main/java/com/union/union/domain/subscription/repository/MiniAppSubscriptionRepository.java
@@ -3,6 +3,7 @@ package com.union.union.domain.subscription.repository;
 import com.union.union.domain.subscription.entity.MiniAppSubscription;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -34,4 +35,15 @@ public interface MiniAppSubscriptionRepository extends JpaRepository<MiniAppSubs
             "AND s.pushEnabled = true " +
             "AND s.unsubscribedAt IS NULL")
     long countActiveSubscribersOfMiniApp(@Param("miniAppId") Long miniAppId);
+
+    /**
+     * 사용자의 활성 구독을 모두 해지 처리한다(soft). 회원 탈퇴 시 호출.
+     * {@code unsubscribe()} 시맨틱과 동일하게 unsubscribedAt 을 채우고 pushEnabled 를 끈다.
+     * @return 해지된 행 수
+     */
+    @Modifying
+    @Query("UPDATE MiniAppSubscription s " +
+            "SET s.unsubscribedAt = CURRENT_TIMESTAMP, s.pushEnabled = false " +
+            "WHERE s.user.id = :userId AND s.unsubscribedAt IS NULL")
+    int deactivateAllByUserId(@Param("userId") UUID userId);
 }

--- a/src/main/java/com/union/union/domain/user/entity/User.java
+++ b/src/main/java/com/union/union/domain/user/entity/User.java
@@ -71,6 +71,16 @@ public class User extends BaseEntity {
         this.userStatus = UserStatus.WITHDRAWN;
     }
 
+    /**
+     * 탈퇴 시 unique 제약이 걸린 email 을 해제(tombstone 치환)해 동일 이메일로 재가입할 수 있게 한다.
+     * 탈퇴는 영구 조치이므로 원본 email 은 보존하지 않으며, 프로필 이미지 참조도 함께 비운다.
+     * id 기반 tombstone 이라 항상 유일하다.
+     */
+    public void anonymizeOnWithdrawal() {
+        this.email = "withdrawn+" + this.id + "@deleted.union.app";
+        this.profileImage = null;
+    }
+
     public void updateRole(Role role) {
         this.role = role;
     }

--- a/src/main/java/com/union/union/domain/user/service/UserService.java
+++ b/src/main/java/com/union/union/domain/user/service/UserService.java
@@ -1,5 +1,8 @@
 package com.union.union.domain.user.service;
 
+import com.union.union.domain.auth.repository.RefreshTokenRepository;
+import com.union.union.domain.notification.repository.UserFcmTokenRepository;
+import com.union.union.domain.subscription.repository.MiniAppSubscriptionRepository;
 import com.union.union.domain.user.dto.ProfileImageUploadUrlRequestDto;
 import com.union.union.domain.user.dto.UpdateNicknameRequestDto;
 import com.union.union.domain.user.dto.UpdateProfileImageRequestDto;
@@ -9,12 +12,14 @@ import com.union.union.global.common.exception.EntityNotFoundException;
 import com.union.union.global.infra.gcs.GcsService;
 import com.union.union.global.infra.gcs.dto.GcsSignedUrlResponseDto;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -22,6 +27,9 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final GcsService gcsService;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserFcmTokenRepository userFcmTokenRepository;
+    private final MiniAppSubscriptionRepository miniAppSubscriptionRepository;
 
     public User getUser(UUID id) {
         return userRepository.findById(id)
@@ -53,13 +61,35 @@ public class UserService {
 
     @Transactional
     public void withdrawMe(UUID userId) {
-        User user = getUser(userId);
-        user.withdraw();
+        withdrawAndPurge(getUser(userId));
     }
 
     @Transactional
     public void deleteUser(UUID id) {
-        User user = getUser(id);
+        withdrawAndPurge(getUser(id));
+    }
+
+    /**
+     * 탈퇴(본인/관리자 공통) 시 계정의 인증·푸시 흔적을 일괄 정리한다.
+     * - 상태 WITHDRAWN 전환 + email tombstone(재가입 허용) + 프로필 이미지 제거
+     * - refresh 토큰 전체 무효화 → 탈퇴 후 /auth/refresh 로 access 토큰 재발급 차단
+     * - FCM 토큰 전체 삭제 → 탈퇴 기기로 푸시 중단
+     * - 활성 구독 전체 해지 → 미니앱 푸시 타깃에서 제외
+     *
+     * 모든 벌크 연산은 User 가 아닌 자식 엔티티만 대상으로 하며, 같은 트랜잭션에서 해당
+     * 엔티티들을 다시 로드하지 않으므로 영속성 컨텍스트 staleness 문제가 없다.
+     * managed User 는 계속 사용하므로 persistence context 를 clear 하지 않는다.
+     */
+    private void withdrawAndPurge(User user) {
+        UUID userId = user.getId();
         user.withdraw();
+        user.anonymizeOnWithdrawal();
+
+        refreshTokenRepository.revokeAllByUserId(userId);
+        int fcmDeleted = userFcmTokenRepository.deleteAllByUserId(userId);
+        int subsDeactivated = miniAppSubscriptionRepository.deactivateAllByUserId(userId);
+
+        log.info("회원 탈퇴 처리 완료. userId={}, fcmToken 삭제={}, 구독 해지={}",
+                userId, fcmDeleted, subsDeactivated);
     }
 }


### PR DESCRIPTION
## 요약

회원 탈퇴/로그아웃 시 계정의 인증·푸시 흔적을 제대로 정리하도록 백엔드 계정 라이프사이클을 하드닝합니다. iOS에 회원 탈퇴/올바른 로그아웃을 추가하면서 발견한 서버측 prod 갭을 메웁니다.

### 배경 (발견된 갭)
- `UserService.withdrawMe()`가 `user.withdraw()`(상태만 `WITHDRAWN`)만 수행 → 탈퇴 후에도:
  - refresh 토큰이 살아 있어 `POST /auth/refresh`로 access 토큰을 계속 재발급 가능
  - FCM 토큰이 남아 탈퇴한 기기로 푸시가 계속 발송
  - 미니앱 구독이 활성으로 남아 푸시 타깃에 잔존
  - unique `email` 제약이 그대로라 동일(대학) 이메일로 재가입 불가
- `AuthService.refresh()`에 `userStatus` 검사가 없어, 정지(`suspend()`는 토큰을 revoke하지 않음)·탈퇴 계정이 미만료 refresh 토큰으로 토큰을 무한 재발급 가능

## 변경 내용

**B1. 탈퇴/관리자삭제 하드닝** (`UserService.withdrawMe`·`deleteUser` → 공통 `withdrawAndPurge`)
- refresh 토큰 전체 무효화(`revokeAllByUserId`, 기존 메서드)
- FCM 토큰 전체 삭제(`UserFcmTokenRepository.deleteAllByUserId` 신규)
- 활성 구독 전체 해지(`MiniAppSubscriptionRepository.deactivateAllByUserId` 신규, `unsubscribe()`와 동일 시맨틱)
- email tombstone 치환(`User.anonymizeOnWithdrawal()`) — unique 제약 해제로 동일 이메일 재가입 허용, 프로필 이미지 참조 제거

**B2. refresh 시 `userStatus` 검증** (`AuthService.refresh`)
- 토큰 재발급 전 `userStatus == ACTIVE` 확인. 비활성 계정이면 전체 토큰 무효화 후 거부.
- 매 요청 DB 조회 없이 단일 choke point(refresh)에서 막아, 정지/탈퇴 계정의 토큰 무한 재발급 구멍 차단.

**B3. 로그아웃을 기기 단위(per-token)로 전환** (`AuthController.logout`·`AuthService.logout`)
- `POST /api/v1/auth/logout`이 사용자의 *모든* refresh 토큰을 무효화하던 것을, 요청 본문 `refreshToken`(해당 기기 세션)만 무효화하도록 변경. 토큰 미제공 시(구버전 클라이언트) 전체 무효화 폴백(하위 호환).
- 효과: (1) 멀티기기에서 한 기기 로그아웃이 다른 기기 세션을 끊지 않음, (2) iOS의 best-effort 로그아웃 정리가 늦게 도착해도 재로그인한 새 세션의 토큰을 무효화하지 않음(codex가 반복 지적한 logout↔재로그인 race 근본 해결).
- `LogoutRequestDto` 추가. 본인 토큰일 때만 처리하며 불일치 시 무시(타 사용자 토큰 무효화 방지).

> 스키마 변경 없음(컬럼 추가 X). `ddl-auto: update` 환경에서 안전. 운영 배포 없이 PR만.

## 자가 검증
- `./gradlew compileJava --rerun-tasks` → **BUILD SUCCESSFUL**
- 테스트: 저장소의 유일한 테스트가 `@SpringBootTest contextLoads()`로 전체 컨텍스트(DB·Redis·GCS·Firebase)를 부팅해야 해, 운영 인프라 없이 실행 불가(배포도 `-x test`). 따라서 컴파일 + 코드리뷰로 검증.

## codex 리뷰 반영
- **consult(범위 점검)**: "refresh가 userStatus를 검사하지 않음", "탈퇴 시 email unique가 재가입을 막음" 지적 → B2 및 email tombstone으로 반영. `@Param` 명시·bulk 연산 `int` 반환·`clearAutomatically` 미사용(managed `User` 유지) 등 메커닉 권고 반영.
- **review/challenge(iOS 측 다회)**: 로그아웃↔재로그인 race를 반복 지적 → 본 PR의 **B3(per-token 로그아웃)**으로 양쪽(서버+iOS) 근본 해결.
- **review(전체 diff)**: "도입된 정합성 이슈 없음(GATE: PASS)".
- 기각: per-요청 userStatus 재검증 필터 — 매 요청 DB 조회 비용(단일 인스턴스 Cloud Run). B2로 핵심 위험은 차단되며, 잔여 노출은 기존 access 토큰의 최대 30분뿐. 후속 권고로만 남김.

## 남은 수동 확인
- 운영 DB의 기존 `WITHDRAWN` 사용자(있다면)는 과거 로직으로 처리돼 토큰/구독이 남아 있을 수 있음 — 필요 시 일회성 정리 스크립트 검토(이번 PR 범위 외).
- 배포는 소유자가 수동 진행(이 PR은 머지/배포하지 않음).
