### PR TITLE
feat(permission): 미니앱별 사용자 권한 결정 도메인 + 스코프 정본 통일

### DIFF
--- a/src/main/java/com/union/union/domain/miniapp/dto/MiniAppResponseDto.java
+++ b/src/main/java/com/union/union/domain/miniapp/dto/MiniAppResponseDto.java
@@ -28,7 +28,7 @@ public record MiniAppResponseDto(
             miniApp.getWorkspace().getName(),
             miniApp.getStatus(),
             miniApp.getTags(),
-            miniApp.getPermissions(),
+            PermissionScope.sanitize(miniApp.getPermissions()),
             miniApp.getAppId(),
             miniApp.getCreatedAt()
         );

--- a/src/main/java/com/union/union/domain/miniapp/entity/PermissionScope.java
+++ b/src/main/java/com/union/union/domain/miniapp/entity/PermissionScope.java
@@ -3,14 +3,21 @@ package com.union.union.domain.miniapp.entity;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * 미니앱이 요청할 수 있는 권한 스코프 (정본).
+ * SDK(union.config.json) · iOS · 대시보드와 동일한 닷-표기 7개로 통일된 계약이다.
+ */
 public enum PermissionScope {
     USER_PROFILE("user.profile"),
-    USER_STUDENT_INFO("user.student_info"),
-    PAYMENT("payment"),
-    LOCATION("location"),
-    NOTIFICATION("notification"),
-    CAMERA("camera"),
-    SHARE("share");
+    USER_EMAIL("user.email"),
+    USER_UNIVERSITY("user.university"),
+    DEVICE_LOCATION("device.location"),
+    DEVICE_CAMERA("device.camera"),
+    DEVICE_STORAGE("device.storage"),
+    NOTIFICATION("notification");
 
     private final String value;
 
@@ -23,11 +30,24 @@ public enum PermissionScope {
         return value;
     }
 
+    /**
+     * 알 수 없는 값은 예외 대신 {@code null} 을 반환하는 관대 파서.
+     * 레거시 JSONB row(payment / share / user.student_info / location / camera 등)가
+     * 엔티티 로드 시 역직렬화 단계에서 500 을 내지 않도록 하기 위함이다.
+     * 호출부는 {@link #sanitize(List)} 로 null 원소를 제거해 사용한다.
+     */
     @JsonCreator
-    public static PermissionScope from(String value) {
+    public static PermissionScope fromNullable(String value) {
+        if (value == null) return null;
         for (PermissionScope scope : values()) {
             if (scope.value.equals(value)) return scope;
         }
-        throw new IllegalArgumentException("알 수 없는 권한 스코프입니다: " + value);
+        return null;
+    }
+
+    /** null / 미지 스코프를 제거한 안전한 리스트를 반환한다. */
+    public static List<PermissionScope> sanitize(List<PermissionScope> scopes) {
+        if (scopes == null) return List.of();
+        return scopes.stream().filter(Objects::nonNull).toList();
     }
 }

--- a/src/main/java/com/union/union/domain/miniapp/service/MiniAppService.java
+++ b/src/main/java/com/union/union/domain/miniapp/service/MiniAppService.java
@@ -20,6 +20,7 @@ import com.union.union.domain.user.repository.UserRepository;
 import com.union.union.domain.workspace.entity.Workspace;
 import com.union.union.domain.workspace.repository.WorkspaceRepository;
 import com.union.union.domain.workspace.service.WorkspaceAuthorizationService;
+import com.union.union.global.common.exception.BadRequestException;
 import com.union.union.global.common.exception.EntityNotFoundException;
 import com.union.union.global.common.exception.UnauthorizedAccessException;
 import com.union.union.global.infra.gcs.GcsService;
@@ -75,6 +76,12 @@ public class MiniAppService {
 
         if (miniAppRepository.existsByAppId(request.appId())) {
             throw new IllegalArgumentException("이미 사용 중인 appId 입니다: " + request.appId());
+        }
+
+        // 관대 파서(PermissionScope.fromNullable)는 미지 스코프를 null 로 바인딩한다.
+        // 레거시 읽기 보호를 위한 leniency 이므로, 신규 등록 시점에는 조용히 삼키지 않고 명시적으로 거부한다.
+        if (request.permissions() != null && request.permissions().contains(null)) {
+            throw new BadRequestException("유효하지 않은 권한 스코프가 포함되어 있습니다");
         }
 
         String tags = (request.keywords() != null && !request.keywords().isEmpty())

--- a/src/main/java/com/union/union/domain/permission/controller/MiniAppPermissionController.java
+++ b/src/main/java/com/union/union/domain/permission/controller/MiniAppPermissionController.java
@@ -1,0 +1,53 @@
+package com.union.union.domain.permission.controller;
+
+import com.union.union.domain.permission.dto.MiniAppPermissionStateDto;
+import com.union.union.domain.permission.dto.UpdatePermissionsRequestDto;
+import com.union.union.domain.permission.dto.UserPermissionGroupDto;
+import com.union.union.domain.permission.service.MiniAppPermissionService;
+import com.union.union.global.security.jwt.JwtUserPrincipal;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 미니앱별 사용자 권한 결정 API.
+ * 모든 엔드포인트는 JWT 인증 필요(SecurityConfig: /api/v1/users/me/** authenticated).
+ */
+@RestController
+@RequiredArgsConstructor
+public class MiniAppPermissionController {
+
+    private final MiniAppPermissionService permissionService;
+
+    /** (a) 미니앱 선언 권한 + 현재 사용자의 결정 조회 (최초 접속 게이트). */
+    @GetMapping("/api/v1/users/me/miniapps/{miniAppId}/permissions")
+    public ResponseEntity<MiniAppPermissionStateDto> getPermissionState(
+            @PathVariable Long miniAppId,
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        return ResponseEntity.ok(permissionService.getPermissionState(principal.userId(), miniAppId));
+    }
+
+    /** (b) 권한 결정 배치 업서트 (동의 모달 / 권한 관리 토글). */
+    @PutMapping("/api/v1/users/me/miniapps/{miniAppId}/permissions")
+    public ResponseEntity<MiniAppPermissionStateDto> updatePermissions(
+            @PathVariable Long miniAppId,
+            @Valid @RequestBody UpdatePermissionsRequestDto request,
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        return ResponseEntity.ok(
+                permissionService.updateDecisions(principal.userId(), miniAppId, request.decisions()));
+    }
+
+    /** (c) 사용자의 전체 권한 결정 목록 (권한 관리 화면). */
+    @GetMapping("/api/v1/users/me/permissions")
+    public ResponseEntity<List<UserPermissionGroupDto>> listUserPermissions(
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        return ResponseEntity.ok(permissionService.listUserDecisions(principal.userId()));
+    }
+}

--- a/src/main/java/com/union/union/domain/permission/dto/MiniAppPermissionStateDto.java
+++ b/src/main/java/com/union/union/domain/permission/dto/MiniAppPermissionStateDto.java
@@ -1,0 +1,14 @@
+package com.union.union.domain.permission.dto;
+
+import java.util.List;
+
+/**
+ * 특정 미니앱에 대한 현재 사용자의 권한 상태 (선언 스코프 + 결정).
+ * 미니앱 최초 접속 게이트와 권한 관리 화면이 소비한다.
+ */
+public record MiniAppPermissionStateDto(
+        Long miniAppId,
+        String appId,
+        List<PermissionItemDto> permissions
+) {
+}

--- a/src/main/java/com/union/union/domain/permission/dto/PermissionDecisionDto.java
+++ b/src/main/java/com/union/union/domain/permission/dto/PermissionDecisionDto.java
@@ -1,0 +1,19 @@
+package com.union.union.domain.permission.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * 권한 스코프 1개에 대한 사용자의 허용/거부 결정.
+ *
+ * @param scope   닷-표기 스코프 (예: "user.profile")
+ * @param granted true = 허용, false = 거부
+ */
+public record PermissionDecisionDto(
+        @NotBlank(message = "scope는 필수입니다")
+        String scope,
+
+        @NotNull(message = "granted는 필수입니다")
+        Boolean granted
+) {
+}

--- a/src/main/java/com/union/union/domain/permission/dto/PermissionItemDto.java
+++ b/src/main/java/com/union/union/domain/permission/dto/PermissionItemDto.java
@@ -1,0 +1,15 @@
+package com.union.union.domain.permission.dto;
+
+/**
+ * 미니앱이 선언한 권한 스코프 1개에 대한 현재 사용자의 상태.
+ *
+ * @param scope       닷-표기 스코프 (예: "device.location")
+ * @param hasDecision 사용자가 이 스코프에 대해 결정을 내린 적이 있는지. false 면 iOS 가 프롬프트해야 함.
+ * @param granted     허용 여부. {@code hasDecision == false} 이면 default-deny 로 항상 false.
+ */
+public record PermissionItemDto(
+        String scope,
+        boolean hasDecision,
+        boolean granted
+) {
+}

--- a/src/main/java/com/union/union/domain/permission/dto/UpdatePermissionsRequestDto.java
+++ b/src/main/java/com/union/union/domain/permission/dto/UpdatePermissionsRequestDto.java
@@ -1,0 +1,16 @@
+package com.union.union.domain.permission.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+/**
+ * 특정 미니앱에 대한 사용자 권한 결정 배치 업서트 요청.
+ */
+public record UpdatePermissionsRequestDto(
+        @NotEmpty(message = "decisions는 비어 있을 수 없습니다")
+        @Valid
+        List<PermissionDecisionDto> decisions
+) {
+}

--- a/src/main/java/com/union/union/domain/permission/dto/UserPermissionGroupDto.java
+++ b/src/main/java/com/union/union/domain/permission/dto/UserPermissionGroupDto.java
@@ -1,0 +1,15 @@
+package com.union.union.domain.permission.dto;
+
+import java.util.List;
+
+/**
+ * 권한 관리 화면용 — 미니앱 단위로 묶은 사용자의 권한 결정 + 미니앱 메타(name/icon).
+ */
+public record UserPermissionGroupDto(
+        Long miniAppId,
+        String appId,
+        String miniAppName,
+        String iconUrl,
+        List<PermissionItemDto> permissions
+) {
+}

--- a/src/main/java/com/union/union/domain/permission/entity/MiniAppUserPermission.java
+++ b/src/main/java/com/union/union/domain/permission/entity/MiniAppUserPermission.java
@@ -1,0 +1,64 @@
+package com.union.union.domain.permission.entity;
+
+import com.union.union.domain.miniapp.entity.PermissionScope;
+import com.union.union.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+/**
+ * 사용자(user) × 미니앱(miniApp) × 권한 스코프(scope) 별 동의 결정.
+ *
+ * <p>기존 {@code users} / {@code mini_apps} 테이블과의 스키마 충돌을 피하기 위해
+ * JPA 연관관계(@ManyToOne) 대신 plain {@code userId}(UUID) / {@code miniAppId}(Long) 컬럼으로
+ * 느슨하게 참조한다. 별도 테이블이므로 {@code ddl-auto: update} 에서 안전하게 신규 생성된다.
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "mini_app_user_permissions",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_miniapp_user_perm",
+                columnNames = {"user_id", "mini_app_id", "scope"}
+        ),
+        indexes = {
+                @Index(name = "idx_miniapp_user_perm_user", columnList = "user_id"),
+                @Index(name = "idx_miniapp_user_perm_user_app", columnList = "user_id, mini_app_id")
+        }
+)
+public class MiniAppUserPermission extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "mini_app_id", nullable = false)
+    private Long miniAppId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "scope", nullable = false, length = 30)
+    private PermissionScope scope;
+
+    @Column(name = "granted", nullable = false)
+    private boolean granted;
+
+    @Builder
+    public MiniAppUserPermission(UUID userId, Long miniAppId, PermissionScope scope, boolean granted) {
+        this.userId = userId;
+        this.miniAppId = miniAppId;
+        this.scope = scope;
+        this.granted = granted;
+    }
+
+    public void updateGranted(boolean granted) {
+        this.granted = granted;
+    }
+}

--- a/src/main/java/com/union/union/domain/permission/repository/MiniAppUserPermissionRepository.java
+++ b/src/main/java/com/union/union/domain/permission/repository/MiniAppUserPermissionRepository.java
@@ -1,0 +1,20 @@
+package com.union.union.domain.permission.repository;
+
+import com.union.union.domain.miniapp.entity.PermissionScope;
+import com.union.union.domain.permission.entity.MiniAppUserPermission;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface MiniAppUserPermissionRepository extends JpaRepository<MiniAppUserPermission, Long> {
+
+    List<MiniAppUserPermission> findByUserIdAndMiniAppId(UUID userId, Long miniAppId);
+
+    List<MiniAppUserPermission> findByUserId(UUID userId);
+
+    Optional<MiniAppUserPermission> findByUserIdAndMiniAppIdAndScope(UUID userId, Long miniAppId, PermissionScope scope);
+}

--- a/src/main/java/com/union/union/domain/permission/service/MiniAppPermissionService.java
+++ b/src/main/java/com/union/union/domain/permission/service/MiniAppPermissionService.java
@@ -1,0 +1,146 @@
+package com.union.union.domain.permission.service;
+
+import com.union.union.domain.miniapp.entity.MiniApp;
+import com.union.union.domain.miniapp.entity.PermissionScope;
+import com.union.union.domain.miniapp.repository.MiniAppRepository;
+import com.union.union.domain.permission.dto.MiniAppPermissionStateDto;
+import com.union.union.domain.permission.dto.PermissionDecisionDto;
+import com.union.union.domain.permission.dto.PermissionItemDto;
+import com.union.union.domain.permission.dto.UserPermissionGroupDto;
+import com.union.union.domain.permission.entity.MiniAppUserPermission;
+import com.union.union.domain.permission.repository.MiniAppUserPermissionRepository;
+import com.union.union.global.common.exception.BadRequestException;
+import com.union.union.global.common.exception.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class MiniAppPermissionService {
+
+    private final MiniAppUserPermissionRepository permissionRepository;
+    private final MiniAppRepository miniAppRepository;
+
+    /**
+     * (a) 미니앱이 선언한 스코프 + 현재 사용자의 결정을 조인해 반환한다.
+     * 선언됐으나 결정이 없는 스코프는 {@code hasDecision=false, granted=false}(default-deny).
+     */
+    @Transactional(readOnly = true)
+    public MiniAppPermissionStateDto getPermissionState(UUID userId, Long miniAppId) {
+        MiniApp app = miniAppRepository.findById(miniAppId)
+                .orElseThrow(() -> new EntityNotFoundException("MiniApp을 찾을 수 없습니다. id=" + miniAppId));
+
+        List<PermissionScope> declared = PermissionScope.sanitize(app.getPermissions());
+        Map<PermissionScope, Boolean> decisions = decisionMap(userId, miniAppId);
+
+        List<PermissionItemDto> items = declared.stream()
+                .map(scope -> toItem(scope, decisions))
+                .toList();
+
+        return new MiniAppPermissionStateDto(app.getId(), app.getAppId(), items);
+    }
+
+    /**
+     * (b) 사용자의 권한 결정을 배치 업서트한다. 미니앱이 선언하지 않은 스코프는 400.
+     */
+    public MiniAppPermissionStateDto updateDecisions(UUID userId, Long miniAppId,
+                                                     List<PermissionDecisionDto> decisions) {
+        MiniApp app = miniAppRepository.findById(miniAppId)
+                .orElseThrow(() -> new EntityNotFoundException("MiniApp을 찾을 수 없습니다. id=" + miniAppId));
+
+        Set<PermissionScope> declared = new HashSet<>(PermissionScope.sanitize(app.getPermissions()));
+
+        for (PermissionDecisionDto decision : decisions) {
+            PermissionScope scope = PermissionScope.fromNullable(decision.scope());
+            if (scope == null || !declared.contains(scope)) {
+                throw new BadRequestException("미니앱이 선언하지 않은 권한입니다: " + decision.scope());
+            }
+            upsertDecision(userId, miniAppId, scope, decision.granted());
+        }
+        log.info("권한 결정 업서트. userId={}, miniAppId={}, count={}", userId, miniAppId, decisions.size());
+        return getPermissionState(userId, miniAppId);
+    }
+
+    /**
+     * (c) 사용자의 전체 권한 결정을 미니앱 단위로 묶어 반환한다(권한 관리 화면).
+     * 선언 스코프 + 선언엔 없지만 결정이 남은 stale 스코프까지 노출(철회 가능).
+     */
+    @Transactional(readOnly = true)
+    public List<UserPermissionGroupDto> listUserDecisions(UUID userId) {
+        List<MiniAppUserPermission> rows = permissionRepository.findByUserId(userId);
+        if (rows.isEmpty()) return List.of();
+
+        Map<Long, Map<PermissionScope, Boolean>> byApp = new LinkedHashMap<>();
+        for (MiniAppUserPermission row : rows) {
+            byApp.computeIfAbsent(row.getMiniAppId(), k -> new LinkedHashMap<>())
+                    .put(row.getScope(), row.isGranted());
+        }
+
+        Map<Long, MiniApp> apps = miniAppRepository.findAllById(byApp.keySet()).stream()
+                .collect(Collectors.toMap(MiniApp::getId, a -> a));
+
+        List<UserPermissionGroupDto> result = new ArrayList<>();
+        for (Map.Entry<Long, Map<PermissionScope, Boolean>> entry : byApp.entrySet()) {
+            MiniApp app = apps.get(entry.getKey());
+            if (app == null) continue; // 삭제된 미니앱의 잔여 결정은 노출하지 않음
+
+            Map<PermissionScope, Boolean> decisions = entry.getValue();
+
+            // 선언 스코프 우선, 이어서 선언엔 없지만 결정이 남은 stale 스코프 (순서 보존)
+            LinkedHashSet<PermissionScope> scopes = new LinkedHashSet<>(PermissionScope.sanitize(app.getPermissions()));
+            scopes.addAll(decisions.keySet());
+
+            List<PermissionItemDto> items = scopes.stream()
+                    .map(scope -> toItem(scope, decisions))
+                    .toList();
+
+            result.add(new UserPermissionGroupDto(
+                    app.getId(), app.getAppId(), app.getName(), app.getIconUrl(), items));
+        }
+        return result;
+    }
+
+    // --- helpers ---
+
+    private Map<PermissionScope, Boolean> decisionMap(UUID userId, Long miniAppId) {
+        return permissionRepository.findByUserIdAndMiniAppId(userId, miniAppId).stream()
+                .collect(Collectors.toMap(MiniAppUserPermission::getScope,
+                        MiniAppUserPermission::isGranted, (a, b) -> b));
+    }
+
+    private PermissionItemDto toItem(PermissionScope scope, Map<PermissionScope, Boolean> decisions) {
+        boolean hasDecision = decisions.containsKey(scope);
+        return new PermissionItemDto(scope.getValue(), hasDecision, decisions.getOrDefault(scope, false));
+    }
+
+    /**
+     * find-then-update/insert 업서트. 동일 사용자가 단일 기기에서 순차 호출하므로 경합은 사실상 없고,
+     * 극히 드문 동시 삽입은 {@code uk_miniapp_user_perm} unique 제약이 최종 보루다(SubscriptionService 패턴과 동일).
+     */
+    private void upsertDecision(UUID userId, Long miniAppId, PermissionScope scope, boolean granted) {
+        permissionRepository.findByUserIdAndMiniAppIdAndScope(userId, miniAppId, scope)
+                .ifPresentOrElse(
+                        existing -> existing.updateGranted(granted),
+                        () -> permissionRepository.save(MiniAppUserPermission.builder()
+                                .userId(userId)
+                                .miniAppId(miniAppId)
+                                .scope(scope)
+                                .granted(granted)
+                                .build())
+                );
+    }
+}


### PR DESCRIPTION
## 요약
미니앱별 **사용자 권한 결정**을 저장하는 별도 도메인/테이블을 추가하고, `PermissionScope` enum을 SDK·iOS·대시보드와 동일한 **정본 7개(닷-표기)**로 통일합니다.

## 배경
- 백엔드는 미니앱이 *선언한* 권한을 `mini_apps.permissions`(JSONB)에 이미 저장하지만, *사용자별 동의 결정*을 저장할 곳이 없었습니다.
- 스코프가 3중 불일치였습니다: SDK/CLI는 닷-표기 7개, 백엔드 enum은 `location/camera/payment/share/user.student_info`. SDK가 보내는 `device.location` 등은 `@JsonCreator`에서 예외가 났습니다.

## 변경 사항
- **`PermissionScope` 정렬**: `user.profile/email/university`, `device.location/camera/storage`, `notification`. `@JsonCreator`를 **관대 파서**(`fromNullable`, 미지값 → `null`)로 바꿔 레거시 JSONB 행(`payment` 등) 역직렬화 시 500을 방지하고, `sanitize()`로 읽기 지점에서 null 원소 제거.
- **신규 `domain/permission/`**: `MiniAppUserPermission` 엔티티 — 별도 테이블 `mini_app_user_permissions`, JPA 연관관계 없이 plain `user_id`(UUID)/`mini_app_id`(Long) 컬럼(스키마 결합 최소화), `unique(user_id, mini_app_id, scope)` + 인덱스. repository/service/controller/dto 포함.
- **엔드포인트(모두 JWT 인증)**:
  - `GET  /api/v1/users/me/miniapps/{miniAppId}/permissions` — 선언 권한 + 사용자 결정
  - `PUT  /api/v1/users/me/miniapps/{miniAppId}/permissions` — 결정 배치 업서트
  - `GET  /api/v1/users/me/permissions` — 전체 결정 목록(권한 관리 화면)
- **등록 하드닝**: 관대 파서가 조용히 삼키지 않도록, `POST /mini-apps`에 미지 스코프가 오면 명시적 400 거부.

## 스키마 안전성
- `ddl-auto: update` — 신규 테이블만 추가, 기존 `users`/`mini_apps` 미변경. enum 값은 JSONB 문자열이라 DDL 변화 없음.
- 배포 불필요(PR까지).

## 검증
- `./gradlew compileJava`, `./gradlew compileTestJava` 통과.
- 런타임(리뷰어/배포 시): `bootRun` → `mini_app_user_permissions` 생성 로그 + 레거시 권한 보유 앱의 `GET /mini-apps/discovery` 무오류 + 실제 JWT로 GET/PUT 왕복.

## 연계 (cross-repo)
스코프 정본 통일은 **union-sdk · union-ios · union-dashboard** PR과 함께 적용됩니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
