### PR TITLE
feat(auth): 미니앱 ID 토큰(RS256) 발급 + JWKS

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+	// JWK 직렬화 (미니앱 ID 토큰 JWKS 공개키 출력용)
+	implementation 'com.nimbusds:nimbus-jose-jwt:9.40'
+
 	// GCS
 	implementation 'com.google.cloud:spring-cloud-gcp-starter-storage:5.1.2'
 

--- a/src/main/java/com/union/union/domain/miniapp/controller/MiniAppController.java
+++ b/src/main/java/com/union/union/domain/miniapp/controller/MiniAppController.java
@@ -32,6 +32,7 @@ public class MiniAppController {
     private final MiniAppService miniAppService;
     private final MiniAppSearchService miniAppSearchService;
     private final MiniAppCategoryRepository miniAppCategoryRepository;
+    private final com.union.union.domain.miniapp.service.MiniAppIdTokenService miniAppIdTokenService;
 
     @GetMapping("/categories")
     public ResponseEntity<List<MiniAppCategoryResponseDto>> getCategories() {
@@ -95,6 +96,19 @@ public class MiniAppController {
     ) {
         String bundleUrl = miniAppService.getLaunchUrl(id, principal.userId());
         return ResponseEntity.ok(Map.of("bundleUrl", bundleUrl));
+    }
+
+    /**
+     * 미니앱(appId) 스코프로 사용자 ID 토큰(RS256)을 발급한다.
+     * native(iOS) 가 사용자 세션으로 인증해 호출하고, 반환된 ID 토큰을 미니앱(WebView)에 전달한다.
+     * publisher 자체 백엔드는 이 토큰을 JWKS 로 검증해 신원을 확인한다(세션 토큰은 노출되지 않음).
+     */
+    @PostMapping("/{id}/id-token")
+    public ResponseEntity<IdTokenResponseDto> issueIdToken(
+            @PathVariable Long id,
+            @AuthenticationPrincipal JwtUserPrincipal principal
+    ) {
+        return ResponseEntity.ok(miniAppIdTokenService.issue(id, principal.userId()));
     }
 
     @GetMapping("/discovery")

--- a/src/main/java/com/union/union/domain/miniapp/dto/IdTokenResponseDto.java
+++ b/src/main/java/com/union/union/domain/miniapp/dto/IdTokenResponseDto.java
@@ -1,0 +1,15 @@
+package com.union.union.domain.miniapp.dto;
+
+/**
+ * 미니앱 ID 토큰 발급 응답.
+ *
+ * @param idToken   RS256 서명 ID 토큰 (publisher 백엔드가 JWKS 로 검증)
+ * @param tokenType "Bearer"
+ * @param expiresIn 만료까지 남은 초
+ */
+public record IdTokenResponseDto(
+    String idToken,
+    String tokenType,
+    long expiresIn
+) {
+}

--- a/src/main/java/com/union/union/domain/miniapp/service/MiniAppIdTokenService.java
+++ b/src/main/java/com/union/union/domain/miniapp/service/MiniAppIdTokenService.java
@@ -1,0 +1,62 @@
+package com.union.union.domain.miniapp.service;
+
+import com.union.union.domain.miniapp.dto.IdTokenResponseDto;
+import com.union.union.domain.miniapp.entity.MiniApp;
+import com.union.union.domain.miniapp.entity.MiniAppStatus;
+import com.union.union.domain.miniapp.entity.PermissionScope;
+import com.union.union.domain.miniapp.repository.MiniAppRepository;
+import com.union.union.domain.permission.service.MiniAppPermissionService;
+import com.union.union.domain.user.entity.User;
+import com.union.union.domain.user.repository.UserRepository;
+import com.union.union.global.common.exception.EntityNotFoundException;
+import com.union.union.global.common.exception.UnauthorizedAccessException;
+import com.union.union.global.security.jwt.AppIdTokenProvider;
+import com.union.union.global.security.jwt.IdTokenProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * 미니앱 ID 토큰 발급 서비스.
+ *
+ * <p>세션 토큰(HS256)을 미니앱에 노출하던 기존 방식을 대체한다. native(iOS) 가 사용자 세션으로
+ * 인증해 호출하면, 해당 미니앱(appId)에 스코프된 ID 토큰(RS256)을 발급한다. publisher 백엔드는
+ * 이 토큰을 JWKS 로 검증해 사용자 신원을 확인한다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MiniAppIdTokenService {
+
+    private final MiniAppRepository miniAppRepository;
+    private final UserRepository userRepository;
+    private final MiniAppPermissionService permissionService;
+    private final AppIdTokenProvider idTokenProvider;
+    private final IdTokenProperties idTokenProperties;
+
+    public IdTokenResponseDto issue(Long miniAppId, UUID userId) {
+        MiniApp miniApp = miniAppRepository.findById(miniAppId)
+                .orElseThrow(() -> new EntityNotFoundException("MiniApp을 찾을 수 없습니다. id=" + miniAppId));
+
+        // launch 와 동일한 접근 게이트: 승인(배포)된 미니앱에 대해서만 ID 토큰을 발급한다.
+        // 이게 없으면 인증된 아무 사용자나 임의 미니앱(미승인/비공개 포함) 스코프의 토큰을 발급받을 수 있다.
+        if (miniApp.getStatus() != MiniAppStatus.APPROVED) {
+            throw new UnauthorizedAccessException("배포되지 않은 MiniApp입니다");
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다. id=" + userId));
+
+        Set<PermissionScope> granted = permissionService.getGrantedScopes(userId, miniAppId);
+        String idToken = idTokenProvider.createIdToken(user, miniApp.getAppId(), granted);
+
+        log.info("미니앱 ID 토큰 발급. miniAppId={}, appId={}, userId={}, grantedScopes={}",
+                miniAppId, miniApp.getAppId(), userId, granted);
+        return new IdTokenResponseDto(idToken, "Bearer", idTokenProperties.expiration() / 1000);
+    }
+}

--- a/src/main/java/com/union/union/domain/permission/service/MiniAppPermissionService.java
+++ b/src/main/java/com/union/union/domain/permission/service/MiniAppPermissionService.java
@@ -114,6 +114,18 @@ public class MiniAppPermissionService {
         return result;
     }
 
+    /**
+     * (d) 사용자가 해당 미니앱에 실제로 동의(granted=true)한 스코프 집합을 반환한다.
+     * ID 토큰 발급 시 어떤 신원 claim 을 담을지 결정하는 데 쓴다.
+     */
+    @Transactional(readOnly = true)
+    public Set<PermissionScope> getGrantedScopes(UUID userId, Long miniAppId) {
+        return permissionRepository.findByUserIdAndMiniAppId(userId, miniAppId).stream()
+                .filter(MiniAppUserPermission::isGranted)
+                .map(MiniAppUserPermission::getScope)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
     // --- helpers ---
 
     private Map<PermissionScope, Boolean> decisionMap(UUID userId, Long miniAppId) {

--- a/src/main/java/com/union/union/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/union/union/global/security/config/SecurityConfig.java
@@ -67,6 +67,9 @@ public class SecurityConfig {
                 // GET summary/events: 퍼블리셔 대시보드 (@PreAuthorize 로 세부 인가)
                 .requestMatchers(HttpMethod.GET, "/api/v1/analytics/**").authenticated()
 
+                // JWKS (Public) — publisher 백엔드가 미니앱 ID 토큰 검증용 공개키 조회
+                .requestMatchers(HttpMethod.GET, "/.well-known/jwks.json").permitAll()
+
                 // Banner endpoints (Public) — Home 캐러셀 노출용
                 .requestMatchers(HttpMethod.GET, "/banners").permitAll()
 

--- a/src/main/java/com/union/union/global/security/jwt/AppIdTokenProvider.java
+++ b/src/main/java/com/union/union/global/security/jwt/AppIdTokenProvider.java
@@ -1,0 +1,133 @@
+package com.union.union.global.security.jwt;
+
+import com.union.union.domain.miniapp.entity.PermissionScope;
+import com.union.union.domain.user.entity.User;
+import io.jsonwebtoken.Jwts;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.security.KeyFactory;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Set;
+
+/**
+ * 미니앱 ID 토큰(RS256) 발급기. {@link JwtProvider}(세션 토큰, HS256)와 평행 구조다.
+ *
+ * <p>발급한 토큰은 publisher 자체 백엔드가 {@code /.well-known/jwks.json} 공개키로 검증한다.
+ * {@code aud}=appId 로 스코프되어 Union 1st-party API 에는 통하지 않는다(세션 토큰과 분리).
+ */
+@Slf4j
+@Component
+public class AppIdTokenProvider {
+
+    private final RSAPrivateKey privateKey;
+    private final RSAPublicKey publicKey;
+    private final String issuer;
+    private final String kid;
+    private final long expiration;
+    private final boolean enabled;
+
+    public AppIdTokenProvider(IdTokenProperties properties) {
+        this.issuer = properties.issuer();
+        this.kid = properties.kid();
+        this.expiration = properties.expiration();
+
+        // 키 미설정이면 부팅을 막지 않고 기능만 비활성화한다(기존 prod 무중단 배포 보호).
+        // IDTOKEN_PRIVATE_KEY 가 주입되면 ID 토큰 발급/JWKS 가 활성화된다.
+        if (properties.privateKey() == null || properties.privateKey().isBlank()) {
+            log.warn("idtoken.private-key 미설정 — 미니앱 ID 토큰 발급/JWKS 비활성화 상태로 기동");
+            this.privateKey = null;
+            this.publicKey = null;
+            this.enabled = false;
+            return;
+        }
+        // 키가 있으면 활성화 — issuer/kid/expiration 도 유효해야 검증 가능한 토큰이 나온다.
+        if (issuer == null || issuer.isBlank() || kid == null || kid.isBlank() || expiration <= 0) {
+            throw new IllegalStateException(
+                    "idtoken issuer/kid/expiration 설정이 유효하지 않습니다 (issuer/kid 비어있거나 expiration<=0)");
+        }
+        RSAPrivateCrtKey crtKey = parsePrivateKey(properties.privateKey());
+        this.privateKey = crtKey;
+        this.publicKey = derivePublicKey(crtKey);
+        this.enabled = true;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * 사용자 신원을 담은 ID 토큰을 미니앱(appId) 스코프로 발급한다.
+     * {@code sub}(userId)는 항상 포함하고, 프로필 claim 은 사용자가 동의한 scope 에 한해 추가한다.
+     */
+    public String createIdToken(User user, String appId, Set<PermissionScope> grantedScopes) {
+        if (!enabled) {
+            throw new IllegalStateException("미니앱 ID 토큰 발급이 비활성화되어 있습니다 (idtoken.private-key 미설정)");
+        }
+        Date now = new Date();
+        var builder = Jwts.builder()
+                .header().keyId(kid).and()
+                .issuer(issuer)
+                .audience().add(appId).and()
+                .subject(user.getId().toString())
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + expiration))
+                .claim("token_use", "id");
+
+        if (grantedScopes.contains(PermissionScope.USER_PROFILE)) {
+            builder.claim("nickname", user.getNickname());
+            if (user.getProfileImage() != null) {
+                builder.claim("profileImage", user.getProfileImage());
+            }
+        }
+        if (grantedScopes.contains(PermissionScope.USER_EMAIL)) {
+            builder.claim("email", user.getEmail());
+        }
+        if (grantedScopes.contains(PermissionScope.USER_UNIVERSITY) && user.getUniversityName() != null) {
+            builder.claim("university", user.getUniversityName());
+        }
+
+        return builder.signWith(privateKey, Jwts.SIG.RS256).compact();
+    }
+
+    public RSAPublicKey getPublicKey() {
+        return publicKey;
+    }
+
+    public String getKid() {
+        return kid;
+    }
+
+    private static RSAPrivateCrtKey parsePrivateKey(String pem) {
+        if (pem == null || pem.isBlank()) {
+            throw new IllegalStateException("idtoken.private-key 가 설정되지 않았습니다 (IDTOKEN_PRIVATE_KEY)");
+        }
+        String base64 = pem
+                .replace("-----BEGIN PRIVATE KEY-----", "")
+                .replace("-----END PRIVATE KEY-----", "")
+                .replaceAll("\\s", "");
+        try {
+            byte[] der = Base64.getDecoder().decode(base64);
+            KeyFactory factory = KeyFactory.getInstance("RSA");
+            return (RSAPrivateCrtKey) factory.generatePrivate(new PKCS8EncodedKeySpec(der));
+        } catch (Exception e) {
+            throw new IllegalStateException("idtoken RSA private key 파싱 실패 (PKCS#8 PEM 이어야 함)", e);
+        }
+    }
+
+    private static RSAPublicKey derivePublicKey(RSAPrivateCrtKey crtKey) {
+        try {
+            KeyFactory factory = KeyFactory.getInstance("RSA");
+            return (RSAPublicKey) factory.generatePublic(
+                    new RSAPublicKeySpec(crtKey.getModulus(), crtKey.getPublicExponent()));
+        } catch (Exception e) {
+            throw new IllegalStateException("idtoken RSA public key 유도 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/union/union/global/security/jwt/IdTokenProperties.java
+++ b/src/main/java/com/union/union/global/security/jwt/IdTokenProperties.java
@@ -1,0 +1,24 @@
+package com.union.union.global.security.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * 미니앱 ID 토큰(RS256) 발급 설정.
+ *
+ * <p>세션 access token(HS256, {@link JwtProperties})과 별개다. ID 토큰은 publisher 자체
+ * 백엔드가 사용자 신원을 검증하도록 발급하는 OIDC 스타일 토큰으로, 비대칭 서명이라
+ * publisher 는 시크릿 공유 없이 JWKS 공개키로만 검증한다.
+ *
+ * @param issuer     iss claim 이자 JWKS base URL (publisher 는 {issuer}/.well-known/jwks.json 으로 키 조회)
+ * @param expiration 만료(ms)
+ * @param kid        JWK key id (토큰 헤더 + JWKS 매칭용)
+ * @param privateKey RSA private key (PKCS#8 PEM). prod 는 IDTOKEN_PRIVATE_KEY 로 주입, local 은 dev 키.
+ */
+@ConfigurationProperties(prefix = "idtoken")
+public record IdTokenProperties(
+    String issuer,
+    long expiration,
+    String kid,
+    String privateKey
+) {
+}

--- a/src/main/java/com/union/union/global/security/jwt/JwksController.java
+++ b/src/main/java/com/union/union/global/security/jwt/JwksController.java
@@ -1,0 +1,40 @@
+package com.union.union.global.security.jwt;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * JWKS(JSON Web Key Set) 공개 엔드포인트.
+ *
+ * <p>publisher 자체 백엔드가 미니앱 ID 토큰을 검증할 때 여기서 RS256 공개키를 조회한다.
+ * 공개키만 노출하며, 비활성화 상태(키 미설정)면 빈 키셋을 반환한다.
+ */
+@RestController
+public class JwksController {
+
+    private final String jwksJson;
+
+    public JwksController(AppIdTokenProvider idTokenProvider) {
+        if (!idTokenProvider.isEnabled()) {
+            this.jwksJson = "{\"keys\":[]}";
+            return;
+        }
+        RSAKey jwk = new RSAKey.Builder(idTokenProvider.getPublicKey())
+                .keyID(idTokenProvider.getKid())
+                .keyUse(KeyUse.SIGNATURE)
+                .algorithm(JWSAlgorithm.RS256)
+                .build()
+                .toPublicJWK();
+        this.jwksJson = new JWKSet(jwk).toString();
+    }
+
+    @GetMapping(value = "/.well-known/jwks.json", produces = MediaType.APPLICATION_JSON_VALUE)
+    public String jwks() {
+        return jwksJson;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,6 +63,14 @@ jwt:
 internal-jwt:
   secret: ${INTERNAL_JWT_SECRET:default-internal-jwt-secret-key-must-be-at-least-256-bits-long-for-hs256}
 
+# 미니앱 ID 토큰(RS256). publisher 백엔드가 JWKS({issuer}/.well-known/jwks.json)로 검증한다.
+# private-key 미설정이면 발급/JWKS 가 비활성화된 채 기동(기존 prod 무중단). prod 는 IDTOKEN_PRIVATE_KEY 주입.
+idtoken:
+  issuer: ${IDTOKEN_ISSUER:http://localhost:8080}
+  expiration: 3600000            # 1시간
+  kid: ${IDTOKEN_KID:union-idtoken-1}
+  private-key: ${IDTOKEN_PRIVATE_KEY:}
+
 careernet:
   api:
     key: ${CAREERNET_API_KEY}

--- a/src/test/java/com/union/union/global/security/jwt/AppIdTokenProviderTest.java
+++ b/src/test/java/com/union/union/global/security/jwt/AppIdTokenProviderTest.java
@@ -1,0 +1,93 @@
+package com.union.union.global.security.jwt;
+
+import com.union.union.domain.miniapp.entity.PermissionScope;
+import com.union.union.domain.user.entity.User;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.util.Base64;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class AppIdTokenProviderTest {
+
+    private static final String ISSUER = "https://union-api.test";
+    private static final String KID = "test-kid-1";
+    private static final String APP_ID = "com.union.taxi-pot";
+
+    private AppIdTokenProvider provider;
+    private User user;
+    private final UUID userId = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() throws Exception {
+        KeyPairGenerator gen = KeyPairGenerator.getInstance("RSA");
+        gen.initialize(2048);
+        KeyPair keyPair = gen.generateKeyPair();
+        String pem = "-----BEGIN PRIVATE KEY-----\n"
+                + Base64.getMimeEncoder().encodeToString(keyPair.getPrivate().getEncoded())
+                + "\n-----END PRIVATE KEY-----";
+
+        provider = new AppIdTokenProvider(new IdTokenProperties(ISSUER, 3_600_000L, KID, pem));
+
+        user = mock(User.class);
+        when(user.getId()).thenReturn(userId);
+        when(user.getNickname()).thenReturn("준서");
+        when(user.getEmail()).thenReturn("test@dankook.ac.kr");
+        when(user.getProfileImage()).thenReturn(null);
+        when(user.getUniversityName()).thenReturn("단국대학교");
+    }
+
+    private Claims parse(String token) {
+        return Jwts.parser()
+                .verifyWith(provider.getPublicKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    @Test
+    void 토큰은_공개키로_검증되고_핵심_claim을_담는다() {
+        String token = provider.createIdToken(user, APP_ID, Set.of());
+
+        Claims claims = parse(token);
+        assertThat(claims.getIssuer()).isEqualTo(ISSUER);
+        assertThat(claims.getAudience()).contains(APP_ID);
+        assertThat(claims.getSubject()).isEqualTo(userId.toString());
+        assertThat(claims.get("token_use", String.class)).isEqualTo("id");
+        assertThat(claims.getExpiration()).isAfter(claims.getIssuedAt());
+    }
+
+    @Test
+    void user_profile_동의시_nickname을_포함한다() {
+        String token = provider.createIdToken(user, APP_ID, Set.of(PermissionScope.USER_PROFILE));
+        assertThat(parse(token).get("nickname", String.class)).isEqualTo("준서");
+    }
+
+    @Test
+    void 동의하지_않은_scope의_claim은_제외된다() {
+        // user.profile / user.email 미동의 → nickname/email 없음, university 만 동의
+        String token = provider.createIdToken(user, APP_ID, Set.of(PermissionScope.USER_UNIVERSITY));
+
+        Claims claims = parse(token);
+        assertThat(claims.get("nickname")).isNull();
+        assertThat(claims.get("email")).isNull();
+        assertThat(claims.get("university", String.class)).isEqualTo("단국대학교");
+    }
+
+    @Test
+    void 헤더에_kid가_있어_JWKS와_매칭된다() {
+        String token = provider.createIdToken(user, APP_ID, Set.of());
+        String headerJson = new String(Base64.getUrlDecoder().decode(token.split("\\.")[0]));
+        assertThat(headerJson).contains("\"kid\":\"" + KID + "\"");
+        assertThat(headerJson).contains("\"alg\":\"RS256\"");
+    }
+}


### PR DESCRIPTION
## 배경
미니앱(WebView)이 자체 백엔드에 신원을 증명하려고 `Union.auth.getAccessToken()`을 쓰는데, 이게 사용자의 **1st-party Union 세션 토큰**(HS256, 모든 Union API 인증 가능)을 그대로 넘겨 token-confusion 결함이 있었음. publisher가 그 토큰을 사용자로서 replay 가능.

## 변경
Union을 IdP로: 미니앱별 스코프 **ID 토큰(RS256)** 발급.
- `AppIdTokenProvider` — RS256 서명, claim: `iss`/`aud`=appId/`sub`=userId, 동의한 권한 scope에 한해 `nickname`/`email`/`university`
- `POST /mini-apps/{id}/id-token` — 승인(APPROVED)된 미니앱만 발급(launch와 동일 인가 게이트)
- `GET /.well-known/jwks.json` — publisher 백엔드가 시크릿 공유 없이 JWKS로 검증
- 키 미설정 시 부팅 막지 않고 비활성(기존 prod 무중단). **prod 배포 시 `IDTOKEN_PRIVATE_KEY`(RSA PKCS#8)+`IDTOKEN_ISSUER` 주입 필요**
- nimbus-jose-jwt 추가(JWK 직렬화), `AppIdTokenProviderTest` 단위테스트

## 검증
`./gradlew test` ID 토큰 단위테스트 통과. codex 코드리뷰 반영(발급 인가 게이트 추가).